### PR TITLE
Create factory for creating a stacked widget with a list of widget titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 ## v **
 * Fixes FormDockWidget by setting a FormWidget is set as the DockWidget's widget
+* Adds a factory for creating a StackedWidget

--- a/eqt/ui/UIStackedWidget.py
+++ b/eqt/ui/UIStackedWidget.py
@@ -5,6 +5,22 @@ from PySide2.QtWidgets import QHBoxLayout, QListWidget, QStackedWidget, QWidget
 
 
 class UIStackedWidget(object):
+    '''
+             QWidget or QDockWidget
+    +----------------------------------------------------------+
+    |        QHBoxLayout                                       |
+    |   +---------------------------------------------------+  |
+    |   |                                                   |  |
+    |   |    +--------------+   +------------------------+  |  |
+    |   |    |   QList      |   |  QStackedWidget        |  |  |
+    |   |    |              |   |                        |  |  |
+    |   |    |              |   |                        |  |  |
+    |   |    +--------------+   +------------------------+  |  |
+    |   |                                                   |  |
+    |   +---------------------------------------------------+  |
+    |                                                          |
+    +----------------------------------------------------------+
+    '''
 
     def createStack(self):
         self.stack_list = QListWidget()
@@ -79,6 +95,11 @@ class StackedDockWidget(QtWidgets.QDockWidget):
 
 
 class StackedWidgetFactory(QWidget):
+    '''creates a StackedWidget with a list of the widgets' titles
+    to the left hand side.
+    The returned dockWidget must be added with
+    main_window.addDockWidget(QtCore.Qt.RightDockWidgetArea, dockWidget)
+    '''
 
     def getQDockWidget(parent=None, title=None):
         return StackedDockWidget(parent)

--- a/eqt/ui/UIStackedWidget.py
+++ b/eqt/ui/UIStackedWidget.py
@@ -41,7 +41,7 @@ class UIStackedWidget(object):
         self.Stack.addWidget(widget)
         self.tabs[title] = widget
         self.num_tabs += 1
-        height_multiplier = self.num_tabs + 1
+        height_multiplier = self.num_tabs + 1.3
         self.stack_list.setMaximumWidth(
             self.stack_list.sizeHintForColumn(0)*1.2 + self.margin_size*2)
         self.stack_list.setMaximumHeight(

--- a/eqt/ui/UIStackedWidget.py
+++ b/eqt/ui/UIStackedWidget.py
@@ -1,0 +1,87 @@
+from eqt.ui.UIFormWidget import UIFormFactory
+from PySide2 import QtWidgets
+from PySide2.QtCore import Qt
+from PySide2.QtWidgets import QHBoxLayout, QListWidget, QStackedWidget, QWidget
+
+
+class UIStackedWidget(object):
+
+    def createStack(self):
+        self.stack_list = QListWidget()
+        self.margin_size = 20
+        self.stack_list.setStyleSheet("margin : {}px".format(self.margin_size))
+
+        self.Stack = QStackedWidget(self)
+
+        hbox = QHBoxLayout(self)
+        hbox.addWidget(self.stack_list)
+        hbox.addWidget(self.Stack)
+        hbox.setAlignment(self.stack_list, Qt.AlignTop)
+
+        self.setLayout(hbox)
+        self.stack_list.currentRowChanged.connect(self.display)
+
+        self.tabs = {}
+
+        self.num_tabs = 0
+        self.widgets = {}
+
+    def display(self, i):
+        self.Stack.setCurrentIndex(i)
+
+    def currentIndex(self):
+        return self.Stack.currentIndex()
+
+    def addTab(self, title, widget='form'):
+        self.stack_list.addItem(title)
+
+        if widget == 'form':
+            widget = UIFormFactory.getQWidget(self)
+
+        self.Stack.addWidget(widget)
+        self.tabs[title] = widget
+        self.num_tabs += 1
+        height_multiplier = self.num_tabs + 1
+        self.stack_list.setMaximumWidth(
+            self.stack_list.sizeHintForColumn(0)*1.2 + self.margin_size*2)
+        self.stack_list.setMaximumHeight(
+            self.stack_list.sizeHintForRow(0)*height_multiplier
+            + self.margin_size*2)
+
+    def addTabs(self, titles):
+        for title in titles:
+            self.addTab(title=title)
+
+
+class StackedWidget(QWidget, UIStackedWidget):
+    def __init__(self, parent=None):
+        # dockWidgetContents = QtWidgets.QWidget()
+
+        QtWidgets.QWidget.__init__(self, parent)
+        self.createStack()
+
+
+class StackedDockWidget(QtWidgets.QDockWidget):
+    def __init__(self, parent=None, title=None):
+
+        QtWidgets.QDockWidget.__init__(self, parent)
+        widget = StackedWidget(parent)
+        self.setWidget(widget)
+        if title is not None:
+            self.setObjectName(title)
+            self.setWindowTitle(title)
+
+    def addTab(self, title, widget='form'):
+        self.widget().addTab(title, widget)
+
+    def addTabs(self, titles):
+        self.widget().addTabs(titles)
+
+
+class StackedWidgetFactory(QWidget):
+
+    def getQDockWidget(parent=None, title=None):
+        return StackedDockWidget(parent)
+
+    def getQWidget(parent=None):
+        return StackedWidget(parent)


### PR DESCRIPTION
By default, has a vertical layout:
![image](https://user-images.githubusercontent.com/60604372/123955377-6f961180-d9a1-11eb-86d0-26f7caec93e8.png)


Or can set layout='horizontal', then looks like this:

![image](https://user-images.githubusercontent.com/60604372/123922171-a9eeb700-d97f-11eb-8a15-8fb7762d6d58.png)
