### PR TITLE
Update to v1.4.3 of conda publish action

### DIFF
--- a/.github/workflows/conda_build_and_publish.yml
+++ b/.github/workflows/conda_build_and_publish.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: publish-to-conda
-      uses: paskino/conda-package-publish-action@v1.4.2
+      uses: paskino/conda-package-publish-action@v1.4.3
       with:
         subDir: 'conda'
         channels: 'conda-forge'


### PR DESCRIPTION
This version of the action supports publishing noarch packages