### PR TITLE
Allow automatic numbering of tabs in StackedWidget

### DIFF
--- a/eqt/ui/UIStackedWidget.py
+++ b/eqt/ui/UIStackedWidget.py
@@ -153,7 +153,12 @@ class UIStackedWidget(object):
         label: str
             The label of the tab to be returned.
             Note, the label may be different to the tab's title.'''
-        return self.tab[label]
+        return self.tabs[label]
+
+    def getTabs(self):
+        ''' return the dict of tabs'''
+        print(self.tabs)
+        return self.tabs
 
 
 
@@ -180,6 +185,13 @@ class StackedDockWidget(QtWidgets.QDockWidget):
 
     def addTabs(self, titles):
         self.widget().addTabs(titles)
+
+    def getTab(self, label):
+        return self.widget().getTab(label)
+
+    def getTabs(self):
+        print("get tabs")
+        return self.widget().getTabs()
 
 
 class StackedWidgetFactory(QWidget):

--- a/eqt/ui/UIStackedWidget.py
+++ b/eqt/ui/UIStackedWidget.py
@@ -146,6 +146,16 @@ class UIStackedWidget(object):
         for label in labels:
             self.addTab(label)
 
+    def getTab(self, label):
+        ''' return the tab with label: label
+        Parameter
+        ---------
+        label: str
+            The label of the tab to be returned.
+            Note, the label may be different to the tab's title.'''
+        return self.tab[label]
+
+
 
 class StackedWidget(QWidget, UIStackedWidget):
     def __init__(self, parent=None, layout='vertical'):

--- a/eqt/ui/UIStackedWidget.py
+++ b/eqt/ui/UIStackedWidget.py
@@ -189,7 +189,6 @@ class StackedDockWidget(QtWidgets.QDockWidget):
         return self.widget().getTab(label)
 
     def getTabs(self):
-        print("get tabs")
         return self.widget().getTabs()
 
 

--- a/eqt/ui/UIStackedWidget.py
+++ b/eqt/ui/UIStackedWidget.py
@@ -157,7 +157,6 @@ class UIStackedWidget(object):
 
     def getTabs(self):
         ''' return the dict of tabs'''
-        print(self.tabs)
         return self.tabs
 
 

--- a/eqt/ui/UIStackedWidget.py
+++ b/eqt/ui/UIStackedWidget.py
@@ -86,14 +86,40 @@ class UIStackedWidget(object):
     def currentIndex(self):
         return self.Stack.currentIndex()
 
-    def addTab(self, title, widget='form'):
+    def addTab(self, label, widget='form', title=None, number_title=True):
+        ''' Adds a tab to the StackedWidget.
+        
+        Parameters
+        ----------
+        label: str
+            The name that will be used to refer to the tab.
+        title: str
+            The name the tab will be listed as in the QListWidget.
+        number_title: bool, default True
+            Determines whether the title of the tab is generated 
+            by adding a number in front of the label. E.g. if the
+            label is "FBP" and this is the first tab that has been
+            added then the title will be "1 - FBP" if number_title
+            has been set to True and title=None
+        widget: QWidget or str: 'form', default 'form'
+            the widget that will be contained in the tab.
+            by default this is set to 'form' which means an empty
+            FormWidget is created'''
+
+        if title is None:
+            if number_title:
+                title_num = len(self.tabs) + 1
+                title = "{} - {}".format(str(title_num), label)
+            else:
+                raise Exception('''The title of the tab has not been set.
+                    Please set title - this must be a string, or set number_title to True.''')
         self.stack_list.addItem(title)
 
         if widget == 'form':
             widget = UIFormFactory.getQWidget(self)
 
         self.Stack.addWidget(widget)
-        self.tabs[title] = widget
+        self.tabs[label] = widget
         self.num_tabs += 1
         height_multiplier = self.num_tabs + 1
         if self.layout_type != 'vertical':
@@ -107,9 +133,18 @@ class UIStackedWidget(object):
         self.stack_list.setMaximumHeight(
             self.stack_list.sizeHintForRow(0)*height_multiplier)
 
-    def addTabs(self, titles):
-        for title in titles:
-            self.addTab(title=title)
+    def addTabs(self, labels):
+        '''
+        Adds multiple tabs to the StackedWidget
+        All tabs contain an empty FormWidget and their title is
+        their label, plus they are numbered according to their order.
+        Parameters
+        ----------
+        labels: list of str
+            The names that will be used to refer to the tabs.
+        '''
+        for label in labels:
+            self.addTab(label)
 
 
 class StackedWidget(QWidget, UIStackedWidget):


### PR DESCRIPTION
The tab will be added to the tabs dictionary with the key name being `'label'`, but the title of the tab will include a number which is automatically added based on the tab ordering.

E.g. if the label is `"FBP"` and it is the first tab, the title will automatically be set to `"1 -FBP"`.
To retrive the tab, we just have to call `self.tabs["FBP"]` or `getTab("FBP")`
Previously to have the title `"1 - FBP"` we would have had to give `"1 - FBP" `as an input to `addTab` - and to retrieve the tab call `self.tabs["1 - FBP"]`

This means that throughout the code where a StackWidget is used, we don't have to refer to a tab by it's number, and makes it much easier to allow different tab orderings or different numbers of tabs to be shown.