### PR TITLE
Delete ErrorObserver as it has been moved to the CILViewer

### DIFF
--- a/eqt/threading/QtThreading.py
+++ b/eqt/threading/QtThreading.py
@@ -86,22 +86,3 @@ class WorkerSignals(QtCore.QObject):
     progress = QtCore.Signal(int)
     message = QtCore.Signal(str)
     status = QtCore.Signal(tuple)
-
-class ErrorObserver:
-
-   def __init__(self):
-       self.__ErrorOccurred = False
-       self.__ErrorMessage = None
-       self.CallDataType = 'string0'
-
-   def __call__(self, obj, event, message):
-       self.__ErrorOccurred = True
-       self.__ErrorMessage = message
-
-   def ErrorOccurred(self):
-       occ = self.__ErrorOccurred
-       self.__ErrorOccurred = False
-       return occ
-
-   def ErrorMessage(self):
-       return self.__ErrorMessage


### PR DESCRIPTION
closes #44 