### PR TITLE
SessionMainWindow Base class for saving and loading sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@
 - Adds `io.py` - contains method for zipping a directory, used by SessionsMainWindow.py
 - Adds unit tests to cover `SessionsDialogs.py`, `io.py`, and a large proportion of `SessionsMainWindow.py`
 
-
 ## v0.5.0
 * Add getWidgets method to FormWidget, FormDockWidget and FormDialog
 * Add setWidgetVisibility method to FormWidget, FormDockWidget and FormDialog 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@
 - Adds unit tests to cover: `saveAllWidgetStates`, `restoreAllSavedWidgetStates`, `getAllWidgetStates`, `getWidgetState`, `applyWidgetState`, `applyWidgetStates`
 - setup.py:
   - Always normalise the version from git describe to pep440
+- Adds `SessionsMainWindow.py` - which is a base class for our apps which create a session folder where any files generated in the app are saved, and provides the ability to permanently save and reload sessions.
+- Adds `SessionsMainWindow_example.py` - an example of using the SessionsMainWindow - you can run this example, change the state of widgets in the form, save the session, reload the session and see the state of the widgets be restored.
+- Adds `SessionsDialogs.py` - the dialogs used by the SessionsMainWindow.py
+- Adds `io.py` - contains method for zipping a directory, used by SessionsMainWindow.py
+- Adds unit tests to cover `SessionsDialogs.py`, `io.py`, and a large proportion of `SessionsMainWindow.py`
+
 
 ## v0.5.0
 * Add getWidgets method to FormWidget, FormDockWidget and FormDialog

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -28,6 +28,7 @@ requirements:
   run:
     - python
     - pyside2
+    - qdarkstyle
 
 about:
   home: https://github.com/paskino/qt-elements

--- a/eqt/io.py
+++ b/eqt/io.py
@@ -34,7 +34,8 @@ def zip_directory(directory, compress=True, **kwargs):
         for r, d, f in os.walk(directory):
             for _file in f:
                 fname = os.path.join(r, _file)
-                zip.write(fname, _file, compress_type=compress_type)
+                arcname = fname[len(directory)+1:]
+                zip.write(fname, arcname, compress_type=compress_type)
                 # Could potentially be used for reporting progress:
                 #progress_callback.emit(os.path.getsize(fname)/total_size)
         zip.close() 

--- a/eqt/io.py
+++ b/eqt/io.py
@@ -14,17 +14,7 @@ def zip_directory(directory, compress=True, **kwargs):
         compress : bool
             Whether to compress the directory.
         '''
-
-
-
         zip = zipfile.ZipFile(directory + '.zip', 'a')
-
-        # Could potentially be used for reporting progress:
-        # total_size = 0
-        # for dirpath, dirnames, filenames in os.walk(directory):
-        #     for f in filenames:
-        #         fp = os.path.join(dirpath, f)
-        #         total_size += os.path.getsize(fp)
 
         if compress:
             compress_type = zipfile.ZIP_DEFLATED
@@ -33,9 +23,7 @@ def zip_directory(directory, compress=True, **kwargs):
 
         for r, d, f in os.walk(directory):
             for _file in f:
-                fname = os.path.join(r, _file)
-                arcname = fname[len(directory)+1:]
-                zip.write(fname, arcname, compress_type=compress_type)
-                # Could potentially be used for reporting progress:
-                #progress_callback.emit(os.path.getsize(fname)/total_size)
+                filepath = os.path.join(r, _file)
+                arcname = os.path.relpath(filepath, directory)
+                zip.write(filepath, arcname, compress_type=compress_type)
         zip.close() 

--- a/eqt/io.py
+++ b/eqt/io.py
@@ -14,16 +14,17 @@ def zip_directory(directory, compress=True, **kwargs):
         compress : bool
             Whether to compress the directory.
         '''
-        zip = zipfile.ZipFile(directory + '.zip', 'a')
+        
+        zipper = zipfile.ZipFile(directory + '.zip', 'a')
 
         if compress:
             compress_type = zipfile.ZIP_DEFLATED
         else:
             compress_type = zipfile.ZIP_STORED
 
-        for r, d, f in os.walk(directory):
+        for r, _, f in os.walk(directory):
             for _file in f:
                 filepath = os.path.join(r, _file)
                 arcname = os.path.relpath(filepath, directory)
-                zip.write(filepath, arcname, compress_type=compress_type)
-        zip.close() 
+                zipper.write(filepath, arcname, compress_type=compress_type)
+        zipper.close() 

--- a/eqt/io.py
+++ b/eqt/io.py
@@ -1,0 +1,40 @@
+import os
+import zipfile
+
+
+
+def zip_directory(directory, compress=True, **kwargs):
+        '''
+        Zips a directory, optionally compressing it.
+        
+        Parameters
+        ----------
+        directory : str
+            The directory to be zipped.
+        compress : bool
+            Whether to compress the directory.
+        '''
+
+
+
+        zip = zipfile.ZipFile(directory + '.zip', 'a')
+
+        # Could potentially be used for reporting progress:
+        # total_size = 0
+        # for dirpath, dirnames, filenames in os.walk(directory):
+        #     for f in filenames:
+        #         fp = os.path.join(dirpath, f)
+        #         total_size += os.path.getsize(fp)
+
+        if compress:
+            compress_type = zipfile.ZIP_DEFLATED
+        else:
+            compress_type = zipfile.ZIP_STORED
+
+        for r, d, f in os.walk(directory):
+            for _file in f:
+                fname = os.path.join(r, _file)
+                zip.write(fname, _file, compress_type=compress_type)
+                # Could potentially be used for reporting progress:
+                #progress_callback.emit(os.path.getsize(fname)/total_size)
+        zip.close() 

--- a/eqt/ui/ProgressTimerDialog.py
+++ b/eqt/ui/ProgressTimerDialog.py
@@ -52,5 +52,7 @@ class ProgressTimerDialog(QProgressDialog):
         # running then it continues forever, 
         # even after the progress window closes.
         self.run_cancelled = True
+        # need to wait for the thread to finish:
+        self.threadpool.waitForDone()
         QProgressDialog.close(self)
 

--- a/eqt/ui/SessionDialogs.py
+++ b/eqt/ui/SessionDialogs.py
@@ -6,6 +6,17 @@ import os
 
 class SaveSessionDialog(FormDialog):
     def __init__(self, parent=None, title="Save Session"):
+        '''
+        A dialog to save a session. Prompts the user for a name for the session, and whether to compress the files.
+
+        Parameters
+        ----------
+        parent : QWidget
+            The parent widget.
+        title : str
+            The title of the dialog.
+        '''
+
         FormDialog.__init__(self, parent, title)
         self.parent = parent
         
@@ -28,6 +39,8 @@ class SaveSessionDialog(FormDialog):
 class SessionDirectorySelectionDialog(FormDialog):
     def __init__(self, parent=None, app_name=None):
         '''
+        A dialog to select a directory in which to save and retrieve sessions.
+
         Parameters
         ----------
         parent : QWidget
@@ -75,6 +88,18 @@ class SessionDirectorySelectionDialog(FormDialog):
 
 class LoadSessionDialog(FormDialog):
     def __init__(self, parent=None, title="Load a Session", location_of_session_files="."):
+        '''
+        A dialog to load a session. Prompts the user to select a session from a list of available sessions.
+
+        Parameters
+        ----------
+        parent : QWidget
+            The parent widget.
+        title : str
+            The title of the dialog.
+        location_of_session_files : str
+            The directory in which to look for session files.
+        '''
         FormDialog.__init__(self, parent, title)
         self.parent = parent
 
@@ -96,6 +121,20 @@ class LoadSessionDialog(FormDialog):
 
 class WarningDialog(QMessageBox):
     def __init__(self, parent=None, message=None, window_title=None, detailed_text=None):
+        '''
+        A dialog to display a warning message.
+        
+        Parameters
+        ----------
+        parent : QWidget
+            The parent widget.
+        message : str
+            The message to display.
+        window_title : str
+            The title of the dialog.
+        detailed_text : str
+            The detailed text to display.
+        '''
         QMessageBox.__init__(self, parent)
         self.setIcon(QMessageBox.Information)
         self.setText(message)
@@ -104,6 +143,21 @@ class WarningDialog(QMessageBox):
 
 class ErrorDialog(QMessageBox):
     def __init__(self, parent=None, message=None, window_title=None, detailed_text=None):
+        '''
+        A dialog to display an error message.
+        The icon is a red circle with a white X.
+        
+        Parameters
+        ----------
+        parent : QWidget
+            The parent widget.
+        message : str
+            The message to display.
+        window_title : str
+            The title of the dialog.
+        detailed_text : str
+            The detailed text to display.
+        '''
         QMessageBox.__init__(self, parent)
         self.setIcon(QMessageBox.Critical)
         self.setText(message)

--- a/eqt/ui/SessionDialogs.py
+++ b/eqt/ui/SessionDialogs.py
@@ -1,5 +1,6 @@
 from eqt.ui import FormDialog
-from PySide2.QtWidgets import (QCheckBox, QComboBox, QFileDialog, QLabel, QLineEdit, QPushButton, QMessageBox)
+from PySide2.QtWidgets import (
+    QCheckBox, QComboBox, QFileDialog, QLabel, QLineEdit, QPushButton, QMessageBox)
 from PySide2 import QtWidgets
 import os
 
@@ -19,7 +20,7 @@ class SaveSessionDialog(FormDialog):
 
         FormDialog.__init__(self, parent, title)
         self.parent = parent
-        
+
         qlabel = QLabel(self.groupBox)
         qlabel.setText("Save session as:")
         qwidget = QLineEdit(self.groupBox)
@@ -62,13 +63,14 @@ class SessionDirectorySelectionDialog(FormDialog):
             label_text = 'Select a session directory to save and retrieve all Sessions:'
 
         else:
-            label_text =f'Select a session directory to save and retrieve all {app_name} Sessions:'
+            label_text = f'Select a session directory to save and retrieve all {app_name} Sessions:'
 
         self.addSpanningWidget(QLabel(label_text), 'select_session_directory')
 
         browse_button = QPushButton('Browse')
         browse_button.clicked.connect(self.browse_for_dir)
-        self.addWidget(browse_button, QLabel('No directory selected'), 'selected_dir')
+        self.addWidget(browse_button, QLabel(
+            'No directory selected'), 'selected_dir')
 
         self.selected_dir = None
 
@@ -77,10 +79,11 @@ class SessionDirectorySelectionDialog(FormDialog):
 
     def browse_for_dir(self):
         dialog = QFileDialog(self.groupBox)
-        directory = dialog.getExistingDirectory(self, "Select a Directory to Save the Session to")
-        self.getWidget('selected_dir', 'label').setText(os.path.basename(directory))
+        directory = dialog.getExistingDirectory(
+            self, "Select a Directory to Save the Session to")
+        self.getWidget('selected_dir', 'label').setText(
+            os.path.basename(directory))
         self.selected_dir = directory
-
 
 
 class LoadSessionDialog(FormDialog):
@@ -100,15 +103,18 @@ class LoadSessionDialog(FormDialog):
         FormDialog.__init__(self, parent, title)
         self.parent = parent
 
-        select_dir_button = QPushButton('Select Directory for Loading Sessions') 
-        self.buttonBox.addButton(select_dir_button,  QtWidgets.QDialogButtonBox.ActionRole)
+        select_dir_button = QPushButton(
+            'Select Directory for Loading Sessions')
+        self.buttonBox.addButton(
+            select_dir_button,  QtWidgets.QDialogButtonBox.ActionRole)
         self.Select = select_dir_button
 
         self.addSpanningWidget(QLabel('Load a Session'), 'load_title')
 
         location_of_session_files = os.path.abspath(location_of_session_files)
 
-        self.addSpanningWidget(QLabel(f'Currently loading sessions from: {location_of_session_files}'), 'sessions_directory')
+        self.addSpanningWidget(QLabel(
+            f'Currently loading sessions from: {location_of_session_files}'), 'sessions_directory')
 
         combo = QComboBox(self.groupBox)
         self.addWidget(combo, 'Select a session:', 'select_session')
@@ -116,11 +122,12 @@ class LoadSessionDialog(FormDialog):
         self.Ok.setText('Load')
         self.Cancel.setText('New Session')
 
+
 class WarningDialog(QMessageBox):
     def __init__(self, parent=None, window_title=None, message=None, detailed_text=None):
         '''
         A dialog to display a warning message.
-        
+
         Parameters
         ----------
         parent : QWidget
@@ -138,12 +145,13 @@ class WarningDialog(QMessageBox):
         self.setWindowTitle(window_title)
         self.setDetailedText(detailed_text)
 
+
 class ErrorDialog(QMessageBox):
     def __init__(self, parent=None, message=None, window_title=None, detailed_text=None):
         '''
         A dialog to display an error message.
         The icon is a red circle with a white X.
-        
+
         Parameters
         ----------
         parent : QWidget

--- a/eqt/ui/SessionDialogs.py
+++ b/eqt/ui/SessionDialogs.py
@@ -132,10 +132,10 @@ class WarningDialog(QMessageBox):
         ----------
         parent : QWidget
             The parent widget.
-        message : str
-            The message to display.
         window_title : str
             The title of the dialog.
+        message : str
+            The message to display.
         detailed_text : str
             The detailed text to display.
         '''
@@ -147,7 +147,7 @@ class WarningDialog(QMessageBox):
 
 
 class ErrorDialog(QMessageBox):
-    def __init__(self, parent=None, message=None, window_title=None, detailed_text=None):
+    def __init__(self, parent=None, window_title=None, message=None, detailed_text=None):
         '''
         A dialog to display an error message.
         The icon is a red circle with a white X.
@@ -156,10 +156,10 @@ class ErrorDialog(QMessageBox):
         ----------
         parent : QWidget
             The parent widget.
-        message : str
-            The message to display.
         window_title : str
             The title of the dialog.
+        message : str
+            The message to display.
         detailed_text : str
             The detailed text to display.
         '''

--- a/eqt/ui/SessionDialogs.py
+++ b/eqt/ui/SessionDialogs.py
@@ -163,3 +163,13 @@ class ErrorDialog(QMessageBox):
         self.setText(message)
         self.setWindowTitle(window_title)
         self.setDetailedText(detailed_text)
+
+
+class AppSettingsDialog(FormDialog):
+
+    def __init__(self, parent=None):
+        super(AppSettingsDialog, self).__init__(parent)
+        self.setWindowTitle("App Settings")
+        dark_checkbox = QCheckBox("Dark Mode")
+        self.addSpanningWidget(dark_checkbox, 'dark_checkbox')
+        self.Ok.setText("Save")

--- a/eqt/ui/SessionDialogs.py
+++ b/eqt/ui/SessionDialogs.py
@@ -80,7 +80,7 @@ class SessionDirectorySelectionDialog(FormDialog):
 
     def browse_for_dir(self):
         dialog = QFileDialog(self.groupBox)
-        directory = dialog.getExistingDirectory(self, "Select Directory to Save Sessions")
+        directory = dialog.getExistingDirectory(self, "Select a Directory to Save the Session to")
         self.getWidget('selected_dir').setText(os.path.basename(directory))
         self.selected_dir = directory
 

--- a/eqt/ui/SessionDialogs.py
+++ b/eqt/ui/SessionDialogs.py
@@ -117,7 +117,7 @@ class LoadSessionDialog(FormDialog):
         self.Cancel.setText('New Session')
 
 class WarningDialog(QMessageBox):
-    def __init__(self, parent=None, message=None, window_title=None, detailed_text=None):
+    def __init__(self, parent=None, window_title=None, message=None, detailed_text=None):
         '''
         A dialog to display a warning message.
         

--- a/eqt/ui/SessionDialogs.py
+++ b/eqt/ui/SessionDialogs.py
@@ -1,0 +1,111 @@
+from eqt.ui import FormDialog
+from PySide2.QtWidgets import (QCheckBox, QComboBox, QFileDialog, QLabel, QLineEdit, QPushButton, QMessageBox)
+from PySide2 import QtWidgets
+import os
+
+
+class SaveSessionDialog(FormDialog):
+    def __init__(self, parent=None, title="Save Session"):
+        FormDialog.__init__(self, parent, title)
+        self.parent = parent
+        
+        qlabel = QLabel(self.groupBox)
+        qlabel.setText("Save session as:")
+        qwidget = QLineEdit(self.groupBox)
+        qwidget.setClearButtonEnabled(True)
+        # finally add to the form widget
+        self.addWidget(qwidget, qlabel, 'session_name')
+
+        qwidget = QCheckBox(self.groupBox)
+        qwidget.setText("Compress Files")
+        qwidget.setEnabled(True)
+        qwidget.setChecked(False)
+        self.addSpanningWidget(qwidget, 'compress')
+
+        self.Ok.setText('Save')
+
+
+class SessionDirectorySelectionDialog(FormDialog):
+    def __init__(self, parent=None, app_name=None):
+        '''
+        Parameters
+        ----------
+        parent : QWidget
+            The parent widget.
+        app_name : str
+            The name of the application.
+
+        Attributes
+        ----------
+        selected_dir : str
+            The selected directory, to be used as the directory in which all sessions are saved.
+        '''
+        FormDialog.__init__(self, parent, "Select Session Directory")
+        self.parent = parent
+
+        self.app_name = app_name
+
+        if app_name is None:
+            label_text = 'Select a session directory to save and retrieve all Sessions:'
+
+        else:
+            label_text =f'Select a session directory to save and retrieve all {app_name} Sessions:'
+
+        self.addSpanningWidget(QLabel(label_text), 'select_session_directory')
+
+
+        self.addSpanningWidget(QLabel('No directory selected'), 'selected_dir')
+
+        browse_button = QPushButton('Browse')
+        browse_button.clicked.connect(self.browse_for_dir)
+        self.addSpanningWidget(browse_button, 'browse_button')
+
+        self.selected_dir = None
+
+        self.Ok.setText('OK')
+        self.Cancel.setEnabled(False)
+
+    def browse_for_dir(self):
+        dialog = QFileDialog(self.groupBox)
+        directory = dialog.getExistingDirectory(self, "Select Directory to Save Sessions")
+        self.getWidget('selected_dir').setText(os.path.basename(directory))
+        self.selected_dir = directory
+
+
+
+class LoadSessionDialog(FormDialog):
+    def __init__(self, parent=None, title="Load a Session", location_of_session_files="."):
+        FormDialog.__init__(self, parent, title)
+        self.parent = parent
+
+        select_dir_button = QPushButton('Select Directory for Loading Sessions') 
+        self.buttonBox.addButton(select_dir_button,  QtWidgets.QDialogButtonBox.ActionRole)
+        self.Select = select_dir_button
+
+        self.addSpanningWidget(QLabel('Load a Session'), 'load_title')
+
+        location_of_session_files = os.path.abspath(location_of_session_files)
+
+        self.addSpanningWidget(QLabel(f'Currently loading sessions from: {location_of_session_files}'), 'sessions_directory')
+
+        combo = QComboBox(self.groupBox)
+        self.addWidget(combo, 'Select a session:', 'select_session')
+
+        self.Ok.setText('Load')
+        self.Cancel.setText('New Session')
+
+class WarningDialog(QMessageBox):
+    def __init__(self, parent=None, message=None, window_title=None, detailed_text=None):
+        QMessageBox.__init__(self, parent)
+        self.setIcon(QMessageBox.Information)
+        self.setText(message)
+        self.setWindowTitle(window_title)
+        self.setDetailedText(detailed_text)
+
+class ErrorDialog(QMessageBox):
+    def __init__(self, parent=None, message=None, window_title=None, detailed_text=None):
+        QMessageBox.__init__(self, parent)
+        self.setIcon(QMessageBox.Critical)
+        self.setText(message)
+        self.setWindowTitle(window_title)
+        self.setDetailedText(detailed_text)

--- a/eqt/ui/SessionDialogs.py
+++ b/eqt/ui/SessionDialogs.py
@@ -66,12 +66,9 @@ class SessionDirectorySelectionDialog(FormDialog):
 
         self.addSpanningWidget(QLabel(label_text), 'select_session_directory')
 
-
-        self.addSpanningWidget(QLabel('No directory selected'), 'selected_dir')
-
         browse_button = QPushButton('Browse')
         browse_button.clicked.connect(self.browse_for_dir)
-        self.addSpanningWidget(browse_button, 'browse_button')
+        self.addWidget(browse_button, QLabel('No directory selected'), 'selected_dir')
 
         self.selected_dir = None
 
@@ -81,7 +78,7 @@ class SessionDirectorySelectionDialog(FormDialog):
     def browse_for_dir(self):
         dialog = QFileDialog(self.groupBox)
         directory = dialog.getExistingDirectory(self, "Select a Directory to Save the Session to")
-        self.getWidget('selected_dir').setText(os.path.basename(directory))
+        self.getWidget('selected_dir', 'label').setText(os.path.basename(directory))
         self.selected_dir = directory
 
 

--- a/eqt/ui/SessionMainWindow.py
+++ b/eqt/ui/SessionMainWindow.py
@@ -45,7 +45,7 @@ class SessionMainWindow(QMainWindow):
         So self.sessions_directory will be: <user selected directory>/<self.sessions_directory_name>
     '''
 
-    def __init__(self, title, app_name, settings_name=None, **kwargs):
+    def __init__(self, title, app_name, settings_name=None, organisation_name=None, **kwargs):
 
         super(SessionMainWindow, self).__init__(**kwargs)
 
@@ -54,8 +54,13 @@ class SessionMainWindow(QMainWindow):
         self.threadpool = QThreadPool()
 
         if settings_name is None:
-            settings_name = title
-        self.settings = QSettings(settings_name, settings_name)
+            settings_name = app_name
+        if organisation_name is None:
+            organisation_name = app_name
+
+        print("Creating settings with name: ", settings_name)
+        
+        self.settings = QSettings(organisation_name, settings_name)
 
         self.setAppStyle()
 

--- a/eqt/ui/SessionMainWindow.py
+++ b/eqt/ui/SessionMainWindow.py
@@ -1,0 +1,634 @@
+import json
+import os
+import shutil
+from datetime import datetime
+from functools import partial
+
+import qdarkstyle
+from eqt.threading import Worker
+from eqt.ui.ProgressTimerDialog import ProgressTimerDialog
+from PySide2.QtCore import QSettings, QThreadPool
+from PySide2.QtGui import QCloseEvent, QKeySequence
+from PySide2.QtWidgets import (QAction, QMainWindow, QMenu)
+from qdarkstyle.dark.palette import DarkPalette
+from qdarkstyle.light.palette import LightPalette
+
+from eqt.ui.SessionDialogs import ErrorDialog, WarningDialog
+from eqt.ui.SessionDialogs import (LoadSessionDialog, SaveSessionDialog,
+                                       SessionDirectorySelectionDialog)
+from eqt.io import zip_directory
+
+
+class SessionMainWindow(QMainWindow):
+    '''
+    A base class for a main window that can save and load sessions.
+    
+    This class provides the following functionality:
+    
+    '''
+
+    def __init__(self, title, app_name, settings_name="", **kwargs):
+
+        super(SessionMainWindow, self).__init__(**kwargs)
+
+        self.threadpool = QThreadPool()
+
+        if settings_name is None:
+            settings_name = title
+        self.settings = QSettings(settings_name, settings_name)
+
+        self.setAppStyle()
+
+        self.menu = self.createMenu()
+
+        self.setWindowTitle(title)
+
+        self.app_name = app_name
+
+        # This is the name of the directory where the session folders are saved
+        # This will be within a directory that is picked by the user
+        # i.e. the location of the session folders will be:
+        # <user selected directory>/<self.sessions_directory_name>
+        self.sessions_directory_name = self.app_name.replace(" ", "-") + "-Sessions"
+        self.sessions_directory = None
+
+        self.setupSession()
+
+        self.should_really_close = False
+
+        self.progress_windows = {}
+
+        
+
+
+    # Create the menu ----------------------------------------------------------
+
+    def createMenu(self):
+        '''Create the menu bar, with the following options:
+
+        File
+            Save
+                This will save the current session
+            Save & Exit
+                This will save the current session and exit the application
+            Exit
+                This will exit the application without saving the current session
+
+        Settings
+            Session Directory
+                This will open a dialog to select the path where the session folders
+                are saved
+
+
+        Notes
+        -----
+        You may wish to override this method to add additional menu options
+        
+        '''
+        
+        menu = self.menuBar()
+
+        file_menu = QMenu("File")
+
+        save_action = QAction("Save", self)
+        save_action.triggered.connect(
+            partial(self.createSaveWindow, event="SaveEvent"))
+        file_menu.addAction(save_action)
+
+        save_exit_action = QAction("Save + Exit", self)
+        save_exit_action.triggered.connect(self.close)
+        file_menu.addAction(save_exit_action)
+
+        exit_action = QAction("Exit", self)
+        exit_action.setShortcut(QKeySequence.Quit)
+        exit_action.triggered.connect(self.close)
+        file_menu.addAction(exit_action)
+
+        settings_menu = QMenu("Settings")
+
+        session_folder_action = QAction("Session Directory", self)
+        session_folder_action.triggered.connect(lambda: self.createSessionsDirectorySelectionDialog(new_session=False))
+        settings_menu.addAction(session_folder_action)
+
+        menu.addMenu(file_menu)
+        menu.addMenu(settings_menu)
+
+        return menu
+
+
+
+    # Loading Sessions ---------------------------------------------------------
+
+    def setupSession(self):
+        '''
+        Loads the appropriate dialogs to allow users to make selections about loading sessions:
+        
+        If this is the first time they open the application, they will be asked to select a directory
+        to store the sessions in. This directory will be stored in the settings, and will be used
+        as the default directory for future sessions. Then, if any sessions exist already in that directory,
+        they will be asked if they want to load one of those sessions, if not, a new session will be created.
+        
+        If this is not the first time they open the application, they will be asked to select a session
+        to load, if any sessions are present in the directory saved in the settings. If they select a session,
+        it will be loaded. If they select "New Session", a new session will be created.
+        '''
+        
+        print("In the settings we have: ", self.settings.value('sessions_folder'))
+        if self.settings.value('sessions_folder') is None:
+            # get user to select directory, then within that directory we create a folder called session_folder_name,
+            # which will then contain all of the session folders.
+            self.createSessionsDirectorySelectionDialog(new_session=True)
+        else:
+            session_folder_name  = self.settings.value('sessions_folder')
+            os.chdir(session_folder_name)
+            self.sessions_directory = session_folder_name
+            self.createSessionSelector()
+
+
+    def createSessionSelector(self):
+        ''''
+        Create a LoadSessionDialog, populated with the names of the sessions
+        saved in the current working directory.
+
+        If no sessions exist, create a new session
+        '''
+        temp_folders = []
+        for r, d, f in os.walk('.'):
+            for _file in f:
+                if '.zip' in _file and _file[0] == '_':
+                    array = _file.split("_")
+                    if(len(array) > 1):
+                        name = array[-2] + " " + array[-1]
+                        name = name[:-4]
+                        temp_folders.append(name)
+
+        if len(temp_folders) == 0: 
+            self.loadSessionNew()
+        else:
+            dialog = LoadSessionDialog(parent=self, location_of_session_files=self.sessions_directory)
+            dialog.widgets['select_session_field'].addItems(temp_folders)
+            dialog.Ok.clicked.connect(self.loadSessionLoad)
+            dialog.Select.clicked.connect(lambda: self.selectLoadSessionsDirectorySelectedInSessionSelector(dialog))
+            dialog.Cancel.clicked.connect(self.loadSessionNew)
+            self.SessionSelectionWindow = dialog
+            dialog.open()
+
+    def selectLoadSessionsDirectorySelectedInSessionSelector(self, load_session_dialog):
+        '''
+        When the user selects the "Select Directory for Loading Sessions" button in the LoadSessionDialog, this method
+        will be called. It will close the LoadSessionDialog, and open a SessionDirectorySelectionDialog
+        to allow the user to select a directory in which the list of sessions will be loaded from.
+        '''
+        load_session_dialog.close()
+        self.createSessionsDirectorySelectionDialog(new_session=True)
+
+
+    def createSessionsDirectorySelectionDialog(self, new_session=False):
+        '''
+        Create a SessionDirectorySelectionDialog, which allows the user to select
+        a directory in which the sessions folder will be created.
+
+        Opens the dialog, and connects the Ok button to the appropriate method
+
+        Parameters
+        ----------
+        new_session : bool
+            Whether or not this method is called straight after the user has opened the application
+        '''
+        session_folder_selection_dialog = SessionDirectorySelectionDialog(parent=self, app_name=self.app_name)
+
+        if new_session:
+            # Move on to creating directory and loading session names
+            session_folder_selection_dialog.Ok.clicked.connect(lambda: self.onSessionDirectorySelectionDialogOkNewSession(session_folder_selection_dialog))
+        else:
+            # Splitting the path and the folder name, means that we only display the folder name that the user has selected
+            # and not the full path including the self.sessions_directory_name:
+            session_folder_selection_dialog.Ok.clicked.connect(lambda: self.onSessionDirectorySelectionDialogOkInSession(session_folder_selection_dialog))
+            session_folder_selection_dialog.Cancel.setEnabled(True)
+            session_folder_selection_dialog.Cancel.clicked.connect(session_folder_selection_dialog.close)
+
+        if self.sessions_directory is not None:
+                session_folder_selection_dialog.getWidget('selected_dir').setText(os.path.split(self.sessions_directory)[0])
+                session_folder_selection_dialog.selected_dir = os.path.split(self.sessions_directory)[0]
+
+        session_folder_selection_dialog.open()
+
+        return session_folder_selection_dialog
+
+    def onSessionDirectorySelectionDialogOkNewSession(self, session_folder_selection_dialog):
+        '''
+        Runs if the user selects Ok on the SessionDirectorySelectionDialog when creating a new session
+        '''
+        if session_folder_selection_dialog.selected_dir is not None:
+            self.createSessionsDirectoryAndMakeSessionSelector(session_folder_selection_dialog.selected_dir)
+            session_folder_selection_dialog.close()
+        # TODO: potentially add a warning/error isf the user has not picked a dir.
+
+    def onSessionDirectorySelectionDialogOkInSession(self, session_folder_selection_dialog):
+        '''
+        Runs if the user selects Ok on the SessionDirectorySelectionDialog when in a session
+        '''
+        if session_folder_selection_dialog.selected_dir is not None:
+            self.createSessionsDirectory(session_folder_selection_dialog.selected_dir)
+        session_folder_selection_dialog.close()
+
+
+    def createSessionsDirectoryAndMakeSessionSelector(self, user_chosen_directory):
+        '''
+        Creates the sessions directory, and then calls the method to create the session selector
+        '''
+        self.createSessionsDirectory(user_chosen_directory)
+        self.createSessionSelector()
+
+    def createSessionsDirectory(self, user_selected_directory):
+        '''
+        If the directory selected by the user does not exist, create it, and then create a folder
+        called sessions_directory_name within it.
+        Move into the sessions_directory_name folder, and store the path to that folder in the settings.
+        Also stores the path to self.sessions_directory_name
+        '''
+        # If the user has selected the sessions_directory_name folder, we want to move up a directory
+        # and then create the sessions_directory_name folder within that directory.
+        # This is necessary because if the sessions_directory_name folder already exists and contains
+        # sessions, we don't want to create another sessions_directory_name folder within it, as then the
+        # existing sessions won't be available for loading.
+        
+        if os.path.basename(user_selected_directory) == self.sessions_directory_name:
+            user_selected_directory = os.path.dirname(user_selected_directory)
+        else:
+            if not os.path.isdir(user_selected_directory):
+                os.mkdir(user_selected_directory)
+        os.chdir(user_selected_directory)
+
+        if not os.path.isdir(self.sessions_directory_name):
+            os.mkdir(self.sessions_directory_name)
+        os.chdir(self.sessions_directory_name)
+        print("Setting the value in the settings: ", os.getcwd())
+        self.settings.setValue('sessions_folder', os.getcwd())
+        print("In the settings we have: ", self.settings.value('sessions_folder'))
+        self.sessions_directory = os.path.abspath(os.getcwd())
+
+
+    def loadSessionNew(self):
+        '''
+        Loads a new session
+        '''
+        self.createSessionFolder()
+        if hasattr(self, 'SessionSelectionWindow'):
+            self.SessionSelectionWindow.close()
+
+
+    def loadSessionLoad(self):
+        '''
+        Loads a session from a zip file
+        '''
+
+        folder_name = self.SessionSelectionWindow.widgets['select_session_field'].currentText(
+        )
+
+        process_name = "Loading Session: {}".format(folder_name)
+
+        # Create progress bar which just has an increasing timer:
+        self.process_finished = False
+        self.createUnknownProgressWindow(process_name)
+        config_worker = Worker(self.loadSessionConfig, folder=folder_name)
+        config_worker.signals.finished.connect(lambda: self.finishLoadConfig(process_name))
+        self.threadpool.start(config_worker)
+        self.SessionSelectionWindow.close()
+
+
+
+    def createSessionFolder(self):
+        '''
+        Creates a session folder with the name:
+        <app_name>-<date>-<time>
+        and moves to it.
+        '''
+        # move to eqt MainWindow
+        date_time = datetime.now().strftime("%d-%m-%Y-%H-%M-%S")
+        session_folder_name = '{}-{}-'.format(self.app_name, date_time)
+        os.mkdir(session_folder_name)
+        self.current_session_folder = os.path.abspath(session_folder_name)
+        os.chdir(self.current_session_folder)
+
+
+    def loadSessionConfig(self, folder, **kwargs):
+        '''
+        Unzips a session folder and saves the contents of the .json session file to
+        self.config.
+        
+        
+        Parameters
+        ----------
+        folder : str
+            The folder to load.
+        '''
+
+        selected_text = folder
+        date_and_time = selected_text.split(' ')[-1]
+        selected_folder = ""
+
+        for r, d, f in os.walk('.'):
+            for _file in f:
+                if date_and_time + '.zip' in _file:
+                    selected_folder = os.path.join('.', _file)
+                    break
+
+        print("going to unpack: ", selected_folder)
+
+        shutil.unpack_archive(selected_folder, selected_folder[:-4])
+        loaded_folder= selected_folder[:-4]
+        self.current_session_folder = loaded_folder
+        os.chdir(self.current_session_folder)
+
+        json_filename = "session.json"
+
+        with open(json_filename) as tmp:
+            self.config = json.load(tmp)
+
+    def finishLoadConfig(self, process_name):
+        '''
+        Called when the config file has been loaded.
+        In child classes, you will want to re-implement this function to load
+        the GUI elements.'''
+        self.finishProcess(process_name)
+
+    def finishProcess(self, process_name):
+        '''
+        Called when a process has finished.
+        Closes the progress bar and sets the process_finished flag to True.
+        '''
+        self.progress_windows[process_name].close()
+        self.process_finished = True
+
+
+    # Progress Bar -------------------------------------------------------------
+
+    def createUnknownProgressWindow(self, process_name, title=None, detailed_text=None):
+        '''
+        Creates a progress bar with an unknown duration
+
+        Instead of expecting to receive progress updates, this progress bar counts
+        the number of seconds that have elapsed since it was created.
+
+        This is useful for processes that take a long time, but for which we don't
+        know how long they will take.
+
+        Parameters
+        ----------
+        process_name : str
+            The name of the process to be displayed in the progress bar
+        title : str
+            The title of the progress bar
+        detailed_text : str
+            The detailed text of the progress bar
+        '''
+        print("Creating unknown progress window", process_name)
+
+        progress_window = ProgressTimerDialog(process_name, parent=self)
+        self.saveReferenceToProgressWindow(progress_window, process_name)
+        progress_window.show()
+
+    def saveReferenceToProgressWindow(self, progress_window, process_name):
+        self.progress_windows[process_name] = progress_window
+
+
+
+    # Aesthetic ----------------------------------------------------------------
+
+    def setAppStyle(self):
+        '''Sets app stylesheet, based on user's settings '''
+        if self.settings.value("dark_mode") is None:
+            self.settings.setValue("dark_mode", "true")
+        if self.settings.value("dark_mode") == "true":
+            style = qdarkstyle.load_stylesheet(palette=DarkPalette)
+        else:
+            style = qdarkstyle.load_stylesheet(palette=LightPalette)
+        self.setStyleSheet(style)
+
+    # Handling Closing And Saving Sessions -------------------------------------
+    
+    def closeEvent(self, event):
+        '''
+        Overwrites the default closeEvent to prompt the user to save the session before closing.
+
+        This method occurs when we call self.close() or when the user clicks the X button on the window.
+        '''
+        print("Enters closeEvent")
+        print(event)
+        print(type(event))
+        
+        if not self.should_really_close:
+            self.createSaveWindow(event)
+            event.ignore()
+        else:
+            print("self.should_really_close", self.should_really_close)
+            # event = QCloseEvent()
+            # event.accept()
+            #self.close()
+
+
+    def createSaveWindow(self, event):
+        ''''
+        Creates a dialog which asks the user if they would like to save the session before closing.
+
+        If the event is a QCloseEvent, then the whole app will always be closed, but the user
+        first has an option to save the session.
+
+        If the event is anything else, then the user has the option to save the session, but
+        the app will not be closed.
+
+        Parameters
+        ----------
+        event: 
+            The event which triggered the dialog.
+        '''
+        self.should_really_close = False
+        dialog = SaveSessionDialog(parent=self, title='Save Session')
+        self.SaveWindow = dialog
+        
+        # We have 2 instances of the window.
+        if isinstance(event, QCloseEvent):
+            # This is the case where we are quitting the app and the window asks if we
+            # would like to save
+            dialog.Cancel.clicked.connect(lambda: self.saveQuitDialogRejected(dialog))
+            dialog.Ok.clicked.connect(lambda: self.saveQuitDialogAccepted(dialog))
+            dialog.Cancel.setText('Quit without saving')
+        else:
+            # This is the case where we are just choosing to 'Save' in the file menu
+            # so we never quit the app.
+            dialog.Cancel.clicked.connect(lambda: self.saveDialogRejected(dialog))
+            dialog.Ok.clicked.connect(lambda: self.saveDialogAccepted(dialog))
+            dialog.Cancel.setText('Cancel')
+
+        print("About to open save dialog")
+        dialog.open()
+
+    def saveDialogAccepted(self, dialog):
+        '''
+        Called when the user clicks 'Save' in the save dialog.
+        This saves the session and then closes the dialog.
+        '''
+        print("Save accepted")
+        compress = dialog.widgets['compress_field'].isChecked()
+        dialog.close()
+        print("Calling save session")
+        session_name = dialog.widgets['session_name_field'].text()
+        self.runSaveSessionWorker(session_name, compress, None)
+
+    def saveDialogRejected(self, dialog):
+        '''
+        Called when the user clicks 'Cancel' in the save dialog.
+        This closes the dialog.
+        '''
+        dialog.close()
+        
+    def saveQuitDialogAccepted(self, dialog):
+        '''
+        Called when the user clicks 'Save' in the save and quit dialog.
+        This saves the session and then closes the app.
+        '''
+        print("Save quit accepted")
+        self.should_really_close = True
+        compress = dialog.widgets['compress_field'].isChecked()
+        session_name = dialog.widgets['session_name_field'].text()
+        dialog.close()
+        print("Calling save session")
+        self.runSaveSessionWorker(session_name, compress, QCloseEvent())
+
+    def saveQuitDialogRejected(self, dialog):
+        '''
+        Called when the user clicks 'Quit without saving' in the save and quit dialog.
+        This closes the app.
+        '''
+        self.removeTemp()  # remove tempdir for this session.
+        dialog.close()
+        self.should_really_close = True
+        self.close()
+
+    def runSaveSessionWorker(self, session_name, compress, event):
+        '''
+        Runs self.saveSession in a thread.
+
+        When the thread is finished, it calls self.closeSaveWindow, or self.removeTempAndClose
+        depending on the type of event.
+
+        If the event is a QCloseEvent, then the whole app will always be closed, by calling
+        self.removeTempAndClose.
+
+        If the event is anything else, then the app will not be closed, by calling
+        self.closeSaveWindow.
+        '''
+        print("runSaveSessionWorker")
+        process_name = 'Save Session'
+
+        self.createUnknownProgressWindow(process_name, "Saving", "Saving Session")
+
+        saveSession_worker = Worker(self.saveSession, session_name, compress)
+        if type(event) == QCloseEvent: 
+            saveSession_worker.signals.finished.connect(lambda: self.removeTempAndClose(process_name))
+        else:
+            saveSession_worker.signals.finished.connect(lambda: self.closeSaveWindow(process_name))
+        self.threadpool.start(saveSession_worker)
+
+    def saveSession(self, session_name, compress, **kwargs):
+        '''
+        Save the session to a zip file
+        The zip file contains the session.json file and the nxs files, and any files
+        already in the session folder
+        '''
+        print("saveSession")
+        self.saveSession_config_to_json(session_name)
+        zip_directory(self.current_session_folder, compress)
+
+    def getSessionConfig(self):
+        '''
+        Returns the session config, which is a dictionary containing the session name,
+        the datetime, the list of files in the session folder, the config of all the
+        widgets in the app.
+
+        This must be re-implemented in the child class, to perform the above.
+        '''
+        return {}
+
+
+    def saveSession_config_to_json(self, session_name):
+        '''
+        Saves the session config to a json file in the session folder.
+        '''
+        self.config = self.getSessionConfig()
+
+        now = datetime.now()
+        now_string = now.strftime("%d-%m-%Y-%H-%M")
+        self.config['datetime'] = now_string
+
+        # Create a directory and save the session to it: --------------------------------------------
+
+        new_folder_to_save_to = os.path.join(self.sessions_directory, "_" + session_name + "_" + now_string)
+
+        os.chdir('..')
+        tempdir = shutil.move(self.current_session_folder, new_folder_to_save_to)
+
+        self.current_session_folder = new_folder_to_save_to
+
+        # Session file will always have the same name.
+        # If a session has been reloaded, and saved again, this will overwrite the old session file.
+        session_file = os.path.join(tempdir, "session.json")
+        # print(dict(self.config.items()).items())
+        with open(session_file, "w+") as f:
+            json.dump(self.config, f)
+
+        print("Finished saveSession_config_to_json")
+
+
+
+
+    def removeTempAndClose(self, process_name):
+        '''
+        Removes the temp directory for this session, and closes the app.
+        '''
+        print("Removing temp and closing")
+        self.removeTemp()
+        self.finishProcess(process_name)
+        self.should_really_close = True
+        #self.closeEvent(event)
+        self.close()
+
+    def removeTemp(self):
+        '''
+        Removes the temp directory for this session.
+        '''
+        print("Removing temp and not closing")
+        if hasattr(self, 'session_folder'):
+            try:
+                shutil.rmtree(self.current_session_folder)
+            except FileNotFoundError:
+                os.chdir('..')
+                try:
+                    shutil.rmtree(self.current_session_folder)
+                except FileNotFoundError:
+                    pass
+                except PermissionError as e:
+                    dialog = ErrorDialog(self, str(e))
+                    dialog.open()
+                    self.removeTemp()
+            except PermissionError as e:
+                dialog = ErrorDialog(self, str(e))
+                dialog.open()
+                self.removeTemp()
+
+
+    def closeSaveWindow(self, process_name):
+        '''
+        Closes the save window and moves back to the session folder.
+        '''
+        # move back to session dir in case we moved
+        # out of it for zipping etc. :
+        os.chdir(self.current_session_folder)
+        self.finishProcess(process_name)
+        self.SaveWindow.close()
+
+
+
+
+

--- a/eqt/ui/SessionMainWindow.py
+++ b/eqt/ui/SessionMainWindow.py
@@ -158,8 +158,6 @@ class SessionMainWindow(QMainWindow):
         self.menu_bar = menu_bar
         self.menus = menus
 
-        return menu_bar, menus
-
     def addToMenu(self):
         '''
         You may wish to override this in a child class, to add

--- a/eqt/ui/SessionMainWindow.py
+++ b/eqt/ui/SessionMainWindow.py
@@ -673,7 +673,7 @@ class SessionMainWindow(QMainWindow):
             try:
                 shutil.rmtree(self.current_session_folder)
             except PermissionError as e:
-                dialog = ErrorDialog(self, str(e))
+                dialog = ErrorDialog(self, message=str(e))
                 dialog.exec_()
                 self.removeTemp()
 

--- a/eqt/ui/SessionMainWindow.py
+++ b/eqt/ui/SessionMainWindow.py
@@ -328,7 +328,7 @@ class SessionMainWindow(QMainWindow):
         date_and_time = selected_text.split(' ')[-1]
         selected_folder = ""
 
-        for r, d, f in os.walk('.'):
+        for _, _, f in os.walk('.'):
             for _file in f:
                 if date_and_time + '.zip' in _file:
                     selected_folder = os.path.join('.', _file)

--- a/eqt/ui/SessionMainWindow.py
+++ b/eqt/ui/SessionMainWindow.py
@@ -533,6 +533,8 @@ class SessionMainWindow(QMainWindow):
         '''
         self.moveSessionFolder(session_name)
         self.saveSessionConfigToJson()
+        # Move out of the session folder before zippping:
+        os.chdir('..')
         zip_directory(self.current_session_folder, compress)
 
     def getSessionConfig(self):
@@ -550,6 +552,7 @@ class SessionMainWindow(QMainWindow):
         '''
         Creates a new session folder, and moves the current session folder to it.
         Saves new session folder as self.current_session_folder
+        Moves into the new session folder
         '''
 
         now_string = datetime.now().strftime("%d-%m-%Y-%H-%M")
@@ -557,6 +560,7 @@ class SessionMainWindow(QMainWindow):
         os.chdir('..')
         shutil.move(self.current_session_folder, new_folder_to_save_to)
         self.current_session_folder = new_folder_to_save_to
+        os.chdir(self.current_session_folder)
 
 
     def saveSessionConfigToJson(self):

--- a/eqt/ui/SessionMainWindow.py
+++ b/eqt/ui/SessionMainWindow.py
@@ -227,7 +227,6 @@ class SessionMainWindow(QMainWindow):
         if session_folder_selection_dialog.selected_dir is not None:
             self.createSessionsDirectoryAndMakeSessionSelector(session_folder_selection_dialog.selected_dir)
             session_folder_selection_dialog.close()
-        # TODO: potentially add a warning/error isf the user has not picked a dir.
 
     def onSessionDirectorySelectionDialogOkInSession(self, session_folder_selection_dialog):
         '''
@@ -418,9 +417,6 @@ class SessionMainWindow(QMainWindow):
 
         This method occurs when we call self.close() or when the user clicks the X button on the window.
         '''
-        print("Enters closeEvent")
-        print(event)
-        print(type(event))
         
         if not self.should_really_close:
             self.createSaveWindow(event)

--- a/eqt/ui/SessionMainWindow.py
+++ b/eqt/ui/SessionMainWindow.py
@@ -48,7 +48,8 @@ class SessionMainWindow(QMainWindow):
         <user selected directory>/<self.sessions_directory_name>
     '''
 
-    def __init__(self, title, app_name, settings_name=None, organisation_name=None, **kwargs):
+    def __init__(self, title, app_name, settings_name=None,
+                 organisation_name=None, **kwargs):
 
         super(SessionMainWindow, self).__init__(**kwargs)
 
@@ -60,7 +61,7 @@ class SessionMainWindow(QMainWindow):
             settings_name = app_name
         if organisation_name is None:
             organisation_name = app_name
-    
+
         self.settings = QSettings(organisation_name, settings_name)
 
         self.setAppStyle()
@@ -72,7 +73,8 @@ class SessionMainWindow(QMainWindow):
         # This will be within a directory that is picked by the user
         # i.e. the location of the session folders will be:
         # <user selected directory>/<self.sessions_directory_name>
-        self.sessions_directory_name = self.app_name.replace(" ", "-") + "-Sessions"
+        self.sessions_directory_name = self.app_name.replace(
+            " ", "-") + "-Sessions"
         self.sessions_directory = None
 
         self.setupSession()
@@ -80,8 +82,6 @@ class SessionMainWindow(QMainWindow):
         self.should_really_close = False
 
         self.progress_windows = {}
-
-
 
     # Create the menu ----------------------------------------------------------
 
@@ -117,9 +117,9 @@ class SessionMainWindow(QMainWindow):
             The menu bar
         menus: dict
             A dictionary of the menu names and the corresponding QMenu objects
-        
+
         '''
-        
+
         menu_bar = self.menuBar()
 
         # If we add the menus this way, then the menuBar takes ownership of the menus:
@@ -146,19 +146,20 @@ class SessionMainWindow(QMainWindow):
         settings_menu.addAction(app_settings_action)
 
         session_folder_action = QAction("Set Session Directory", self)
-        session_folder_action.triggered.connect(lambda: self.createSessionsDirectorySelectionDialog(new_session=False))
+        session_folder_action.triggered.connect(
+            lambda: self.createSessionsDirectorySelectionDialog(new_session=False))
         settings_menu.addAction(session_folder_action)
 
         menus = {
             "File": file_menu,
             "Settings": settings_menu
         }
-        
+
         self.menu_bar = menu_bar
         self.menus = menus
 
         return menu_bar, menus
-    
+
     def addToMenu(self):
         '''
         You may wish to override this in a child class, to add
@@ -170,7 +171,6 @@ class SessionMainWindow(QMainWindow):
         '''
 
         pass
-
 
     # Settings -----------------------------------------------------------------
 
@@ -188,22 +188,22 @@ class SessionMainWindow(QMainWindow):
         '''Create a dialog to change the application settings, such as the light/dark theme'''
         dialog = AppSettingsDialog(self)
         self.setAppSettingsDialogWidgets(dialog)
-        dialog.Ok.clicked.connect(lambda: self.onAppSettingsDialogAccepted(dialog))
+        dialog.Ok.clicked.connect(
+            lambda: self.onAppSettingsDialogAccepted(dialog))
         dialog.Cancel.clicked.connect(dialog.close)
         dialog.open()
 
-
     def setAppSettingsDialogWidgets(self, dialog):
-        '''Set the widgets on the app settings dialog, based on the 
+        '''Set the widgets on the app settings dialog, based on the
         current settings of the app'''
         if self.settings.value("dark_mode") == "true":
             dialog.widgets['dark_checkbox_field'].setChecked(True)
         else:
             dialog.widgets['dark_checkbox_field'].setChecked(False)
 
-
     def onAppSettingsDialogAccepted(self, dialog):
-        '''This method is called when the user clicks "Ok" on the app settings dialog'''
+        '''This method is called when the user clicks
+            "Ok" on the app settings dialog'''
         if dialog.widgets['dark_checkbox_field'].isChecked():
             self.settings.setValue("dark_mode", "true")
         else:
@@ -211,33 +211,30 @@ class SessionMainWindow(QMainWindow):
         self.setAppStyle()
         dialog.close()
 
-
-
     # Loading Sessions ---------------------------------------------------------
 
     def setupSession(self):
         '''
         Loads the appropriate dialogs to allow users to make selections about loading sessions:
-        
+
         If this is the first time they open the application, they will be asked to select a directory
         to store the sessions in. This directory will be stored in the settings, and will be used
         as the default directory for future sessions. Then, if any sessions exist already in that directory,
         they will be asked if they want to load one of those sessions, if not, a new session will be created.
-        
+
         If this is not the first time they open the application, they will be asked to select a session
         to load, if any sessions are present in the directory saved in the settings. If they select a session,
         it will be loaded. If they select "New Session", a new session will be created.
         '''
-        
+
         if self.settings.value('sessions_folder') is None:
             # get user to select directory, then within that directory we create a folder called session_folder_name,
             # which will then contain all of the session folders.
             self.createSessionsDirectorySelectionDialog(new_session=True)
         else:
-            session_folder_name  = self.settings.value('sessions_folder')
+            session_folder_name = self.settings.value('sessions_folder')
             self.sessions_directory = session_folder_name
             self.createSessionSelector()
-
 
     def createSessionSelector(self):
         ''''
@@ -251,26 +248,29 @@ class SessionMainWindow(QMainWindow):
             for _file in f:
                 if '.zip' in _file:
                     array = _file.split("_")
-                    if(len(array) > 1):
+                    if (len(array) > 1):
                         date = _file.split("_")[-1]
-                        name = _file.replace("_" + date, "") + " " + date.strip(".zip")
+                        name = _file.replace(
+                            "_" + date, "") + " " + date.strip(".zip")
                         zip_folders.append(name)
 
-        if len(zip_folders) == 0: 
+        if len(zip_folders) == 0:
             self.loadSessionNew()
         else:
-            self.SessionSelectionWindow = self.createLoadSessionDialog(zip_folders)
-            
+            self.SessionSelectionWindow = self.createLoadSessionDialog(
+                zip_folders)
 
     def createLoadSessionDialog(self, zip_folders):
         '''
         Create a LoadSessionDialog, populated with the names of the sessions
         saved in the current working directory.
         '''
-        dialog = LoadSessionDialog(parent=self, location_of_session_files=self.sessions_directory)
+        dialog = LoadSessionDialog(
+            parent=self, location_of_session_files=self.sessions_directory)
         dialog.widgets['select_session_field'].addItems(zip_folders)
         dialog.Ok.clicked.connect(self.loadSessionLoad)
-        dialog.Select.clicked.connect(lambda: self.selectLoadSessionsDirectorySelectedInSessionSelector(dialog))
+        dialog.Select.clicked.connect(
+            lambda: self.selectLoadSessionsDirectorySelectedInSessionSelector(dialog))
         dialog.Cancel.clicked.connect(self.loadSessionNew)
         dialog.open()
 
@@ -285,7 +285,6 @@ class SessionMainWindow(QMainWindow):
         load_session_dialog.close()
         self.createSessionsDirectorySelectionDialog(new_session=True)
 
-
     def createSessionsDirectorySelectionDialog(self, new_session=False):
         '''
         Create a SessionDirectorySelectionDialog, which allows the user to select
@@ -298,21 +297,27 @@ class SessionMainWindow(QMainWindow):
         new_session : bool
             Whether or not this method is called straight after the user has opened the application
         '''
-        session_folder_selection_dialog = SessionDirectorySelectionDialog(parent=self, app_name=self.app_name)
+        session_folder_selection_dialog = SessionDirectorySelectionDialog(
+            parent=self, app_name=self.app_name)
 
         if new_session:
             # Move on to creating directory and loading session names
-            session_folder_selection_dialog.Ok.clicked.connect(lambda: self.onSessionDirectorySelectionDialogOkNewSession(session_folder_selection_dialog))
+            session_folder_selection_dialog.Ok.clicked.connect(
+                lambda: self.onSessionDirectorySelectionDialogOkNewSession(session_folder_selection_dialog))
         else:
             # Splitting the path and the folder name, means that we only display the folder name that the user has selected
             # and not the full path including the self.sessions_directory_name:
-            session_folder_selection_dialog.Ok.clicked.connect(lambda: self.onSessionDirectorySelectionDialogOkInSession(session_folder_selection_dialog))
+            session_folder_selection_dialog.Ok.clicked.connect(
+                lambda: self.onSessionDirectorySelectionDialogOkInSession(session_folder_selection_dialog))
             session_folder_selection_dialog.Cancel.setEnabled(True)
-            session_folder_selection_dialog.Cancel.clicked.connect(session_folder_selection_dialog.close)
+            session_folder_selection_dialog.Cancel.clicked.connect(
+                session_folder_selection_dialog.close)
 
         if self.sessions_directory is not None:
-                session_folder_selection_dialog.getWidget('selected_dir', 'label').setText(os.path.split(self.sessions_directory)[0])
-                session_folder_selection_dialog.selected_dir = os.path.split(self.sessions_directory)[0]
+            session_folder_selection_dialog.getWidget('selected_dir', 'label').setText(
+                os.path.split(self.sessions_directory)[0])
+            session_folder_selection_dialog.selected_dir = os.path.split(
+                self.sessions_directory)[0]
 
         session_folder_selection_dialog.open()
 
@@ -323,7 +328,8 @@ class SessionMainWindow(QMainWindow):
         Runs if the user selects Ok on the SessionDirectorySelectionDialog when creating a new session
         '''
         if session_folder_selection_dialog.selected_dir is not None:
-            self.createSessionsDirectoryAndMakeSessionSelector(session_folder_selection_dialog.selected_dir)
+            self.createSessionsDirectoryAndMakeSessionSelector(
+                session_folder_selection_dialog.selected_dir)
             session_folder_selection_dialog.close()
 
     def onSessionDirectorySelectionDialogOkInSession(self, session_folder_selection_dialog):
@@ -331,9 +337,9 @@ class SessionMainWindow(QMainWindow):
         Runs if the user selects Ok on the SessionDirectorySelectionDialog when in a session
         '''
         if session_folder_selection_dialog.selected_dir is not None:
-            self.createSessionsDirectory(session_folder_selection_dialog.selected_dir)
+            self.createSessionsDirectory(
+                session_folder_selection_dialog.selected_dir)
         session_folder_selection_dialog.close()
-
 
     def createSessionsDirectoryAndMakeSessionSelector(self, user_chosen_directory):
         '''
@@ -354,20 +360,20 @@ class SessionMainWindow(QMainWindow):
         # This is necessary because if the sessions_directory_name folder already exists and contains
         # sessions, we don't want to create another sessions_directory_name folder within it, as then the
         # existing sessions won't be available for loading.
-        
+
         if os.path.basename(user_selected_directory) == self.sessions_directory_name:
             user_selected_directory = os.path.dirname(user_selected_directory)
         else:
             if not os.path.isdir(user_selected_directory):
                 os.mkdir(user_selected_directory)
-        
-        sessions_directory = os.path.abspath(os.path.join(user_selected_directory, self.sessions_directory_name))
+
+        sessions_directory = os.path.abspath(os.path.join(
+            user_selected_directory, self.sessions_directory_name))
 
         if not os.path.isdir(sessions_directory):
             os.mkdir(sessions_directory)
         self.settings.setValue('sessions_folder', sessions_directory)
         self.sessions_directory = sessions_directory
-
 
     def loadSessionNew(self):
         '''
@@ -376,7 +382,6 @@ class SessionMainWindow(QMainWindow):
         self.createSessionFolder()
         if hasattr(self, 'SessionSelectionWindow'):
             self.SessionSelectionWindow.close()
-
 
     def loadSessionLoad(self):
         '''
@@ -392,11 +397,10 @@ class SessionMainWindow(QMainWindow):
         self.process_finished = False
         self.createUnknownProgressWindow(process_name)
         config_worker = Worker(self.loadSessionConfig, folder=folder_name)
-        config_worker.signals.finished.connect(lambda: self.finishLoadConfig(process_name))
+        config_worker.signals.finished.connect(
+            lambda: self.finishLoadConfig(process_name))
         self.threadpool.start(config_worker)
         self.SessionSelectionWindow.close()
-
-
 
     def createSessionFolder(self):
         '''
@@ -405,17 +409,17 @@ class SessionMainWindow(QMainWindow):
         '''
         date_time = datetime.now().strftime("%d-%m-%Y-%H-%M-%S")
         session_folder_name = '{}-{}'.format(self.app_name, date_time)
-        session_folder_path = os.path.join(self.sessions_directory, session_folder_name)
+        session_folder_path = os.path.join(
+            self.sessions_directory, session_folder_name)
         os.mkdir(session_folder_path)
         self.current_session_folder = os.path.abspath(session_folder_path)
-
 
     def loadSessionConfig(self, folder, **kwargs):
         '''
         Unzips a session folder and saves the contents of the .json session file to
         self.config.
-        
-        
+
+
         Parameters
         ----------
         folder : str
@@ -429,14 +433,16 @@ class SessionMainWindow(QMainWindow):
         for _, _, f in os.walk(self.sessions_directory):
             for _file in f:
                 if date_and_time + '.zip' in _file:
-                    selected_folder = os.path.join(self.sessions_directory, _file)
+                    selected_folder = os.path.join(
+                        self.sessions_directory, _file)
                     break
 
         shutil.unpack_archive(selected_folder, selected_folder[:-4])
-        loaded_folder= selected_folder[:-4]
+        loaded_folder = selected_folder[:-4]
         self.current_session_folder = loaded_folder
 
-        json_filename = os.path.join(self.current_session_folder, "session.json")
+        json_filename = os.path.join(
+            self.current_session_folder, "session.json")
 
         with open(json_filename) as tmp:
             self.config = json.load(tmp)
@@ -455,8 +461,6 @@ class SessionMainWindow(QMainWindow):
         '''
         self.process_finished = True
         self.progress_windows[process_name].close()
-        
-
 
     # Progress Bar -------------------------------------------------------------
 
@@ -487,17 +491,15 @@ class SessionMainWindow(QMainWindow):
     def saveReferenceToProgressWindow(self, progress_window, process_name):
         self.progress_windows[process_name] = progress_window
 
-
-
     # Handling Closing And Saving Sessions -------------------------------------
-    
+
     def closeEvent(self, event):
         '''
         Overwrites the default closeEvent to prompt the user to save the session before closing.
 
         This method occurs when we call self.close() or when the user clicks the X button on the window.
         '''
-        
+
         # Need to check that we are not inside the current session folder, as this will either be
         # deleted or moved to a new location.
 
@@ -507,8 +509,7 @@ class SessionMainWindow(QMainWindow):
 
         if not self.should_really_close:
             self.createSaveWindow(event)
-            event.ignore()           
-
+            event.ignore()
 
     def createSaveWindow(self, event):
         ''''
@@ -528,18 +529,21 @@ class SessionMainWindow(QMainWindow):
         self.should_really_close = False
         dialog = SaveSessionDialog(parent=self, title='Save Session')
         self.SaveWindow = dialog
-        
+
         # We have 2 instances of the window.
         if isinstance(event, QCloseEvent):
             # This is the case where we are quitting the app and the window asks if we
             # would like to save
-            dialog.Cancel.clicked.connect(lambda: self.saveQuitDialogRejected(dialog))
-            dialog.Ok.clicked.connect(lambda: self.saveQuitDialogAccepted(dialog))
+            dialog.Cancel.clicked.connect(
+                lambda: self.saveQuitDialogRejected(dialog))
+            dialog.Ok.clicked.connect(
+                lambda: self.saveQuitDialogAccepted(dialog))
             dialog.Cancel.setText('Quit without saving')
         else:
             # This is the case where we are just choosing to 'Save' in the file menu
             # so we never quit the app.
-            dialog.Cancel.clicked.connect(lambda: self.saveDialogRejected(dialog))
+            dialog.Cancel.clicked.connect(
+                lambda: self.saveDialogRejected(dialog))
             dialog.Ok.clicked.connect(lambda: self.saveDialogAccepted(dialog))
             dialog.Cancel.setText('Cancel')
 
@@ -561,7 +565,7 @@ class SessionMainWindow(QMainWindow):
         This closes the dialog.
         '''
         dialog.close()
-        
+
     def saveQuitDialogAccepted(self, dialog):
         '''
         Called when the user clicks 'Save' in the save and quit dialog.
@@ -599,13 +603,16 @@ class SessionMainWindow(QMainWindow):
         process_name = 'Save Session'
 
         self.process_finished = False
-        self.createUnknownProgressWindow(process_name, "Saving", "Saving Session")
+        self.createUnknownProgressWindow(
+            process_name, "Saving", "Saving Session")
 
         saveSession_worker = Worker(self.saveSession, session_name, compress)
-        if type(event) == QCloseEvent: 
-            saveSession_worker.signals.finished.connect(lambda: self.removeTempAndClose(process_name))
+        if type(event) == QCloseEvent:
+            saveSession_worker.signals.finished.connect(
+                lambda: self.removeTempAndClose(process_name))
         else:
-            saveSession_worker.signals.finished.connect(lambda: self.closeSaveWindow(process_name))
+            saveSession_worker.signals.finished.connect(
+                lambda: self.closeSaveWindow(process_name))
         self.threadpool.start(saveSession_worker)
 
     def saveSession(self, session_name, compress, **kwargs):
@@ -628,7 +635,6 @@ class SessionMainWindow(QMainWindow):
         '''
         return {}
 
-
     def moveSessionFolder(self, session_name):
         '''
         Creates a new session folder, and moves the current session folder to it.
@@ -637,16 +643,17 @@ class SessionMainWindow(QMainWindow):
         '''
 
         now_string = datetime.now().strftime("%d-%m-%Y-%H-%M")
-        new_folder_to_save_to = os.path.join(self.sessions_directory, session_name + "_" + now_string)
+        new_folder_to_save_to = os.path.join(
+            self.sessions_directory, session_name + "_" + now_string)
         shutil.move(self.current_session_folder, new_folder_to_save_to)
         self.current_session_folder = new_folder_to_save_to
-
 
     def saveSessionConfigToJson(self):
         '''
         Saves the session config to a json file in the session folder: self.current_session_folder
         '''
-        session_file = os.path.join(self.current_session_folder, "session.json")
+        session_file = os.path.join(
+            self.current_session_folder, "session.json")
 
         self.config = self.getSessionConfig()
 
@@ -657,7 +664,6 @@ class SessionMainWindow(QMainWindow):
 
         with open(session_file, "w+") as f:
             json.dump(self.config, f)
-
 
     def removeTempAndClose(self, process_name):
         '''
@@ -679,7 +685,6 @@ class SessionMainWindow(QMainWindow):
                 dialog = ErrorDialog(self, str(e))
                 dialog.exec_()
                 self.removeTemp()
-
 
     def closeSaveWindow(self, process_name):
         '''

--- a/eqt/ui/SessionMainWindow.py
+++ b/eqt/ui/SessionMainWindow.py
@@ -5,18 +5,18 @@ from datetime import datetime
 from functools import partial
 
 import qdarkstyle
-from eqt.threading import Worker
-from eqt.ui.ProgressTimerDialog import ProgressTimerDialog
 from PySide2.QtCore import QSettings, QThreadPool
 from PySide2.QtGui import QCloseEvent, QKeySequence
-from PySide2.QtWidgets import (QAction, QMainWindow, QMenu)
+from PySide2.QtWidgets import QAction, QMainWindow
 from qdarkstyle.dark.palette import DarkPalette
 from qdarkstyle.light.palette import LightPalette
 
-from eqt.ui.SessionDialogs import ErrorDialog, WarningDialog
-from eqt.ui.SessionDialogs import (LoadSessionDialog, SaveSessionDialog,
-                                       SessionDirectorySelectionDialog)
 from eqt.io import zip_directory
+from eqt.threading import Worker
+from eqt.ui.ProgressTimerDialog import ProgressTimerDialog
+from eqt.ui.SessionDialogs import (ErrorDialog, LoadSessionDialog,
+                                   SaveSessionDialog,
+                                   SessionDirectorySelectionDialog)
 
 
 class SessionMainWindow(QMainWindow):
@@ -146,7 +146,7 @@ class SessionMainWindow(QMainWindow):
         If no sessions exist, create a new session
         '''
         zip_folders = []
-        for r, d, f in os.walk('.'):
+        for _, _, f in os.walk('.'):
             for _file in f:
                 if '.zip' in _file:
                     array = _file.split("_")

--- a/eqt/ui/SessionMainWindow.py
+++ b/eqt/ui/SessionMainWindow.py
@@ -474,6 +474,13 @@ class SessionMainWindow(QMainWindow):
         This method occurs when we call self.close() or when the user clicks the X button on the window.
         '''
         
+        # Need to check that we are not inside the current session folder, as this will either be
+        # deleted or moved to a new location.
+
+        if self.current_session_folder in os.path.abspath(os.getcwd()):
+            # Move out into the folder that contains the session folders:
+            os.chdir(self.sessions_directory)
+
         if not self.should_really_close:
             self.createSaveWindow(event)
             event.ignore()           

--- a/eqt/ui/SessionMainWindow.py
+++ b/eqt/ui/SessionMainWindow.py
@@ -21,10 +21,7 @@ from eqt.io import zip_directory
 
 class SessionMainWindow(QMainWindow):
     '''
-    A base class for a main window that can save and load sessions.
-    
-    This class provides the following functionality:
-    
+    A base class for a main window that can save and load sessions.   
     '''
 
     def __init__(self, title, app_name, settings_name=None, **kwargs):

--- a/eqt/ui/SessionMainWindow.py
+++ b/eqt/ui/SessionMainWindow.py
@@ -14,9 +14,9 @@ from qdarkstyle.light.palette import LightPalette
 from eqt.io import zip_directory
 from eqt.threading import Worker
 from eqt.ui.ProgressTimerDialog import ProgressTimerDialog
-from eqt.ui.SessionDialogs import (ErrorDialog, LoadSessionDialog,
-                                   SaveSessionDialog,
-                                   SessionDirectorySelectionDialog, AppSettingsDialog)
+from eqt.ui.SessionDialogs import (AppSettingsDialog, ErrorDialog,
+                                   LoadSessionDialog, SaveSessionDialog,
+                                   SessionDirectorySelectionDialog)
 
 
 class SessionMainWindow(QMainWindow):
@@ -39,10 +39,13 @@ class SessionMainWindow(QMainWindow):
         the name of the progress window.
     self.sessions_directory
         This is the path to the directory where the session folders are saved.
-        This is set by the user using the menu option "Settings > Set Session Directory".
-        Inside the folder specified by the user, there will be a folder
-        called self.sessions_directory_name, which is where the session folders are saved.
-        So self.sessions_directory will be: <user selected directory>/<self.sessions_directory_name>
+        This is set by the user using the menu option:
+        "Settings > Set Session Directory".
+        Inside the folder specified by the user, there will be a
+        folder called self.sessions_directory_name, which is where
+        the session folders are saved.
+        So self.sessions_directory will be:
+        <user selected directory>/<self.sessions_directory_name>
     '''
 
     def __init__(self, title, app_name, settings_name=None, organisation_name=None, **kwargs):
@@ -57,9 +60,7 @@ class SessionMainWindow(QMainWindow):
             settings_name = app_name
         if organisation_name is None:
             organisation_name = app_name
-
-        print("Creating settings with name: ", settings_name)
-        
+    
         self.settings = QSettings(organisation_name, settings_name)
 
         self.setAppStyle()
@@ -160,7 +161,7 @@ class SessionMainWindow(QMainWindow):
     
     def addToMenu(self):
         '''
-        You may wish to override this in a base class, to add
+        You may wish to override this in a child class, to add
         additional menu options.
 
         The menu bar is available as self.menu_bar, and the menus are
@@ -406,7 +407,7 @@ class SessionMainWindow(QMainWindow):
         session_folder_name = '{}-{}'.format(self.app_name, date_time)
         session_folder_path = os.path.join(self.sessions_directory, session_folder_name)
         os.mkdir(session_folder_path)
-        self.current_session_folder = os.path.abspath(session_folder_name)
+        self.current_session_folder = os.path.abspath(session_folder_path)
 
 
     def loadSessionConfig(self, folder, **kwargs):

--- a/eqt/ui/SessionMainWindow.py
+++ b/eqt/ui/SessionMainWindow.py
@@ -98,7 +98,7 @@ class SessionMainWindow(QMainWindow):
 
         Returns
         -------
-        menu : QMenuBar
+        menu_bar: QMenuBar
             The menu bar
         menus: dict
             A dictionary of the menu names and the corresponding QMenu objects
@@ -110,10 +110,10 @@ class SessionMainWindow(QMainWindow):
         
         '''
         
-        menu = self.menuBar()
+        menu_bar = self.menuBar()
 
         # If we add the menus this way, then the menuBar takes ownership of the menus:
-        file_menu = menu.addMenu("File")
+        file_menu = menu_bar.addMenu("File")
 
         save_action = QAction("Save", self)
         save_action.triggered.connect(
@@ -129,7 +129,7 @@ class SessionMainWindow(QMainWindow):
         exit_action.triggered.connect(self.close)
         file_menu.addAction(exit_action)
 
-        settings_menu = menu.addMenu("Settings")
+        settings_menu = menu_bar.addMenu("Settings")
 
         app_settings_action = QAction("App Settings", self)
         app_settings_action.triggered.connect(self.createAppSettingsDialog)
@@ -144,7 +144,7 @@ class SessionMainWindow(QMainWindow):
             "Settings": settings_menu
         }
 
-        return menu, menus
+        return menu_bar, menus
 
 
     # Settings -----------------------------------------------------------------

--- a/eqt/ui/SessionMainWindow.py
+++ b/eqt/ui/SessionMainWindow.py
@@ -64,7 +64,8 @@ class SessionMainWindow(QMainWindow):
 
         self.setAppStyle()
 
-        self.menu_bar, self.menus = self.createMenu()
+        self.createMenu()
+        self.addToMenu()
 
         # This is the name of the directory where the session folders are saved
         # This will be within a directory that is picked by the user
@@ -102,17 +103,19 @@ class SessionMainWindow(QMainWindow):
                 This will open a dialog to select the path where the session folders
                 are saved
 
+        Sets
+        ----
+        self.menu_bar: QMenuBar
+            The menu bar
+        self.menus: dict
+            A dictionary of the menu names and the corresponding QMenu objects
+
         Returns
         -------
         menu_bar: QMenuBar
             The menu bar
         menus: dict
             A dictionary of the menu names and the corresponding QMenu objects
-
-
-        Notes
-        -----
-        You may wish to override this method to add additional menu options
         
         '''
         
@@ -149,8 +152,23 @@ class SessionMainWindow(QMainWindow):
             "File": file_menu,
             "Settings": settings_menu
         }
+        
+        self.menu_bar = menu_bar
+        self.menus = menus
 
         return menu_bar, menus
+    
+    def addToMenu(self):
+        '''
+        You may wish to override this in a base class, to add
+        additional menu options.
+
+        The menu bar is available as self.menu_bar, and the menus are
+        available as self.menus, which is a dictionary of the menu names
+        and the corresponding QMenu objects.
+        '''
+
+        pass
 
 
     # Settings -----------------------------------------------------------------
@@ -292,7 +310,7 @@ class SessionMainWindow(QMainWindow):
             session_folder_selection_dialog.Cancel.clicked.connect(session_folder_selection_dialog.close)
 
         if self.sessions_directory is not None:
-                session_folder_selection_dialog.getWidget('selected_dir').setText(os.path.split(self.sessions_directory)[0])
+                session_folder_selection_dialog.getWidget('selected_dir', 'label').setText(os.path.split(self.sessions_directory)[0])
                 session_folder_selection_dialog.selected_dir = os.path.split(self.sessions_directory)[0]
 
         session_folder_selection_dialog.open()

--- a/eqt/ui/SessionMainWindow.py
+++ b/eqt/ui/SessionMainWindow.py
@@ -111,13 +111,6 @@ class SessionMainWindow(QMainWindow):
         self.menus: dict
             A dictionary of the menu names and the corresponding QMenu objects
 
-        Returns
-        -------
-        menu_bar: QMenuBar
-            The menu bar
-        menus: dict
-            A dictionary of the menu names and the corresponding QMenu objects
-
         '''
 
         menu_bar = self.menuBar()

--- a/examples/SessionMainWindow_example.py
+++ b/examples/SessionMainWindow_example.py
@@ -80,7 +80,7 @@ def add_every_widget_to_form(form):
 
 def create_main_window():
     window = ExampleSessionMainWindow(
-        "Example Session Main Window{}".format(__version__), "Example1", settings_name="Example2")
+        "Example Session Main Window{}".format(__version__), "Example0", settings_name="Example0")
     
     return window
 

--- a/examples/SessionMainWindow_example.py
+++ b/examples/SessionMainWindow_example.py
@@ -11,7 +11,7 @@ from epac_ct.version import version
 __version__ = version
 
 
-class ExampleMainWindow(SessionMainWindow):
+class ExampleSessionMainWindow(SessionMainWindow):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         form_widget = FormWidget(self)
@@ -71,7 +71,7 @@ def add_every_widget_to_form(form):
 
 
 def create_main_window():
-    window = ExampleMainWindow(
+    window = ExampleSessionMainWindow(
         "Example Session Main Window{}".format(__version__), "Example7-Sessions", settings_name="Example7")
     
     return window

--- a/examples/SessionMainWindow_example.py
+++ b/examples/SessionMainWindow_example.py
@@ -26,6 +26,12 @@ class ExampleSessionMainWindow(SessionMainWindow):
         add_every_widget_to_form(form_widget)
         self.setCentralWidget(form_widget)
 
+    def addToMenu(self):
+        ''' Adds an example extra menu.'''
+        extra_menu = self.menu_bar.addMenu("Extra Menu")
+        self.menu_bar.addMenu(extra_menu)
+        self.menus["Extra"] = extra_menu
+
     def getSessionConfig(self):
         '''
         This function is called when the user wants to save the current session.

--- a/examples/SessionMainWindow_example.py
+++ b/examples/SessionMainWindow_example.py
@@ -1,12 +1,13 @@
 import sys
 
-from eqt.ui.UIFormWidget import FormWidget
-from eqt.ui.UISliderWidget import UISliderWidget
 from PySide2 import QtWidgets
 from PySide2.QtWidgets import QApplication
 
-from epac_ct.qt.SessionMainWindow import SessionMainWindow
-from epac_ct.version import version
+from eqt.ui.SessionMainWindow import SessionMainWindow
+from eqt.ui.UIFormWidget import FormWidget
+from eqt.ui.UISliderWidget import UISliderWidget
+
+from eqt.version import version
 
 __version__ = version
 

--- a/examples/SessionMainWindow_example.py
+++ b/examples/SessionMainWindow_example.py
@@ -1,0 +1,90 @@
+import sys
+
+from eqt.ui.UIFormWidget import FormWidget
+from eqt.ui.UISliderWidget import UISliderWidget
+from PySide2 import QtWidgets
+from PySide2.QtWidgets import QApplication
+
+from epac_ct.qt.SessionMainWindow import SessionMainWindow
+from epac_ct.version import version
+
+__version__ = version
+
+
+class ExampleMainWindow(SessionMainWindow):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        form_widget = FormWidget(self)
+        add_every_widget_to_form(form_widget)
+        self.setCentralWidget(form_widget)
+
+    def getSessionConfig(self):
+        '''
+        This function is called when the user wants to save the current session.
+        We need to add the state of the widgets to the config.
+        
+        Returns
+        -------
+        config : dict
+            The config of the current session.
+        '''
+
+        form_widget = self.centralWidget()
+        all_widget_states = form_widget.getAllWidgetStates()
+
+        config = {'form_widget': all_widget_states}
+
+        return config
+
+    def finishLoadConfig(self, process_name):
+        '''
+        This function is called after the config of the chosen session is loaded.
+        It is used to set the state of the widgets.
+        '''
+        form_widget_config = self.config['form_widget']
+        form_widget = self.centralWidget()
+        form_widget.applyWidgetStates(form_widget_config)
+        super().finishLoadConfig(process_name)
+
+
+def add_every_widget_to_form(form):
+    '''
+    Generate every widget and add it to the form
+
+    Parameters
+    ----------
+    form : FormWidget, FormDialog or FormDockWidget
+        The form to add the widgets to
+    '''
+    form.addWidget(QtWidgets.QLabel('test label'), 'Label: ', 'label')
+    form.addWidget(QtWidgets.QCheckBox('test checkbox'), 'CheckBox: ', 'checkBox')
+    form.addWidget(QtWidgets.QComboBox(), 'ComboBox: ', 'comboBox')
+    form.addWidget(QtWidgets.QDoubleSpinBox(), 'DoubleSpinBox: ', 'doubleSpinBox')
+    form.addWidget(QtWidgets.QSpinBox(), 'SpinBox: ', 'spinBox')
+    form.addWidget(QtWidgets.QSlider(), 'Slider: ', 'slider')
+    form.addWidget(UISliderWidget(QtWidgets.QLabel()), 'UISliderWidget: ', 'uiSliderWidget')
+    form.addWidget(QtWidgets.QRadioButton('test'), 'RadioButton: ', 'radioButton')
+    form.addWidget(QtWidgets.QTextEdit('test'), 'TextEdit: ', 'textEdit')
+    form.addWidget(QtWidgets.QPlainTextEdit('test'), 'PlainTextEdit: ', 'plainTextEdit')
+    form.addWidget(QtWidgets.QLineEdit('test'), 'LineEdit: ', 'lineEdit')
+    form.addWidget(QtWidgets.QPushButton('test'), 'Button: ', 'button')
+
+
+def create_main_window():
+    window = ExampleMainWindow(
+        "Example Session Main Window{}".format(__version__), "Example7-Sessions", settings_name="Example7")
+    
+    return window
+
+
+def main():
+    # open main window:
+    app = QApplication(sys.argv)
+    window = create_main_window()
+    window.show()
+    app.exec_()
+
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/SessionMainWindow_example.py
+++ b/examples/SessionMainWindow_example.py
@@ -12,6 +12,13 @@ __version__ = version
 
 
 class ExampleSessionMainWindow(SessionMainWindow):
+    '''
+    This is an example of a SessionMainWindow.
+    It is used to show how to use the SessionMainWindow class.
+    
+    To test out this example, change the state of the widgets and save the session.
+    Then load the session again and check if the state of the widgets is the same as before.
+    '''
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         form_widget = FormWidget(self)

--- a/examples/SessionMainWindow_example.py
+++ b/examples/SessionMainWindow_example.py
@@ -80,7 +80,7 @@ def add_every_widget_to_form(form):
 
 def create_main_window():
     window = ExampleSessionMainWindow(
-        "Example Session Main Window{}".format(__version__), "Example7-Sessions", settings_name="Example7")
+        "Example Session Main Window{}".format(__version__), "Example1", settings_name="Example2")
     
     return window
 

--- a/examples/progress_timer_dialog_example.py
+++ b/examples/progress_timer_dialog_example.py
@@ -9,7 +9,7 @@ from eqt.ui.SessionDialogs import ErrorDialog
 
 class MainUI(QtWidgets.QMainWindow):
 
-    def __init__(self, parent = None):
+    def __init__(self, parent=None):
         QtWidgets.QMainWindow.__init__(self, parent)
         
         pb = QtWidgets.QPushButton(self)
@@ -63,7 +63,8 @@ class MainUI(QtWidgets.QMainWindow):
         if not hasattr(self, 'progress_windows'):
             self.progress_windows = {}
 
-        progress_window = ProgressTimerDialog(process_name, parent=self, flags=QtCore.Qt.Window)
+        progress_window = ProgressTimerDialog(
+                process_name, parent=self, flags=QtCore.Qt.Window)
 
         self.progress_windows[process_name] = progress_window
         progress_window.show()

--- a/examples/progress_timer_dialog_example.py
+++ b/examples/progress_timer_dialog_example.py
@@ -56,7 +56,7 @@ class MainUI(QtWidgets.QMainWindow):
         raise Exception("Error!!")
 
     def process_error_dialog(self, error, **kwargs):
-        dialog = ErrorDialog(self, str(error[1]), "Error", str(error[2]))
+        dialog = ErrorDialog(self, "Error", str(error[1]), str(error[2]))
         dialog.open()
 
     def create_timer_progress_window(self, process_name):

--- a/examples/progress_timer_dialog_example.py
+++ b/examples/progress_timer_dialog_example.py
@@ -4,6 +4,7 @@ from eqt.ui import ProgressTimerDialog
 from eqt.threading import Worker
 from time import sleep
 from PySide2.QtCore import QThreadPool
+from eqt.ui.SessionDialogs import ErrorDialog
 
 
 class MainUI(QtWidgets.QMainWindow):
@@ -14,9 +15,14 @@ class MainUI(QtWidgets.QMainWindow):
         pb = QtWidgets.QPushButton(self)
         pb.setText("Start Process")
         pb.clicked.connect(lambda: self.startProcess())
+
+        pb2 = QtWidgets.QPushButton(self)
+        pb2.setText("Start Process 2")
+        pb2.clicked.connect(lambda: self.startProcessWithError())
         
         layout = QtWidgets.QHBoxLayout()
         layout.addWidget(pb)
+        layout.addWidget(pb2)
         widg = QtWidgets.QWidget()
         widg.setLayout(layout)
 
@@ -33,8 +39,25 @@ class MainUI(QtWidgets.QMainWindow):
         worker.signals.finished.connect(self.progress_windows[process_name].close)
         self.threadpool.start(worker)
 
+    def startProcessWithError(self):
+        process_name = "My example process, with an error"
+        self.create_timer_progress_window(process_name)
+        worker = Worker(self.example_process_with_error)
+
+        worker.signals.finished.connect(self.progress_windows[process_name].close)
+        worker.signals.error.connect(self.process_error_dialog)
+        self.threadpool.start(worker)
+
     def example_process(self, **kwargs):
         sleep(10)
+
+    def example_process_with_error(self, **kwargs):
+        sleep(3)
+        raise Exception("Error!!")
+
+    def process_error_dialog(self, error, **kwargs):
+        dialog = ErrorDialog(self, str(error[1]), "Error", str(error[2]))
+        dialog.open()
 
     def create_timer_progress_window(self, process_name):
         if not hasattr(self, 'progress_windows'):

--- a/test/test_SessionDialogs.py
+++ b/test/test_SessionDialogs.py
@@ -14,7 +14,10 @@ else:
 print ("skip_as_conda_build is set to ", skip_as_conda_build)
 
 if not skip_as_conda_build:
-    app = QApplication(sys.argv)
+    if not QApplication.instance():
+        app = QApplication(sys.argv)
+    else:
+        app = QApplication.instance()
 else:
     skip_test = True
 
@@ -88,7 +91,7 @@ class TestSessionDirectorySelectionDialog(unittest.TestCase):
         sdsd = SessionDirectorySelectionDialog()
         sdsd.browse_for_dir = unittest.mock.Mock()
         QFileDialog.getExistingDirectory = unittest.mock.Mock()
-        sdsd.getWidget("browse_button").click()       
+        sdsd.getWidget("selected_dir").click()   
         sdsd.browse_for_dir.assert_called_once()
 
     def test_browse_dialog_updates_session_directory_label(self):
@@ -97,7 +100,7 @@ class TestSessionDirectorySelectionDialog(unittest.TestCase):
         QFileDialog.getExistingDirectory = unittest.mock.Mock()
         QFileDialog.getExistingDirectory.return_value = example_dir
         sdsd.browse_for_dir()
-        self.assertEqual(sdsd.getWidget("selected_dir").text(), os.path.basename(example_dir))
+        self.assertEqual(sdsd.getWidget("selected_dir", "label").text(), os.path.basename(example_dir))
 
     def test_browse_dialog_updates_selected_dir_attribute(self):
         example_dir = "C:\\Users\\test_user\\Documents\\test_dir"

--- a/test/test_SessionDialogs.py
+++ b/test/test_SessionDialogs.py
@@ -1,4 +1,4 @@
-from eqt.ui.SessionDialogs import WarningDialog, ErrorDialog, SaveSessionDialog, SessionDirectorySelectionDialog, LoadSessionDialog
+from eqt.ui.SessionDialogs import WarningDialog, ErrorDialog, SaveSessionDialog, SessionDirectorySelectionDialog, LoadSessionDialog, AppSettingsDialog
 import os
 import unittest
 from PySide2.QtWidgets import QApplication, QFileDialog
@@ -122,6 +122,14 @@ class TestLoadSessionDialog(unittest.TestCase):
         location_of_session_files = "C:\\Users\\test_user\\Documents\\test_dir"
         lsd = LoadSessionDialog(location_of_session_files=location_of_session_files)
         self.assertEqual(lsd.getWidget("sessions_directory").text(), "Currently loading sessions from: C:\\Users\\test_user\\Documents\\test_dir")
+
+@unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
+class TestAppSettingsDialog(unittest.TestCase):
+
+    def test_init(self):
+        asd = AppSettingsDialog()
+        assert asd is not None
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_SessionDialogs.py
+++ b/test/test_SessionDialogs.py
@@ -1,0 +1,99 @@
+from eqt.ui.SessionDialogs import WarningDialog, ErrorDialog, SaveSessionDialog, SessionDirectorySelectionDialog, LoadSessionDialog
+import os
+import unittest
+from PySide2.QtWidgets import QApplication
+import sys
+
+# skip the tests on GitHub actions
+if os.environ.get('CONDA_BUILD', '0') == '1':
+    skip_as_conda_build = True
+else:
+    skip_as_conda_build = False
+
+
+print ("skip_as_conda_build is set to ", skip_as_conda_build)
+
+if not skip_as_conda_build:
+    app = QApplication(sys.argv)
+else:
+    skip_test = True
+
+@unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
+class TestWarningDialog(unittest.TestCase):
+    def test_init(self):
+        wd = WarningDialog()
+        assert wd is not None
+
+    def test_init_with_params(self):
+        message = "This is a test message"
+        window_title = "Test Warning Dialog Title"
+        detailed_text = "This is a test detailed text"
+
+        wd = WarningDialog(message=message, window_title=window_title, detailed_text=detailed_text)
+        self.assertEqual(wd.detailedText(), detailed_text)
+        self.assertEqual(wd.text(), message)
+        self.assertEqual(wd.windowTitle(), window_title)
+
+@unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
+class TestErrorDialog(unittest.TestCase):
+    def test_init(self):
+        ed = ErrorDialog()
+        assert ed is not None
+
+    def test_init_with_params(self):
+        message = "This is a test message"
+        window_title = "Test Error Dialog Title"
+        detailed_text = "This is a test detailed text"
+
+        ed = ErrorDialog(message=message, window_title=window_title, detailed_text=detailed_text)
+        self.assertEqual(ed.detailedText(), detailed_text)
+        self.assertEqual(ed.text(), message)
+        self.assertEqual(ed.windowTitle(), window_title)
+
+@unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
+class TestSaveSessionDialog(unittest.TestCase):
+    def test_init(self):
+        ssd = SaveSessionDialog()
+        assert ssd is not None
+
+    def test_init_with_title_param(self):
+        title = "Test Save Session Dialog Title"
+        ssd = SaveSessionDialog(title=title)
+        self.assertEqual(ssd.windowTitle(), title)
+
+@unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
+class TestSessionDirectorySelectionDialog(unittest.TestCase):
+    def test_init(self):
+        sdsd = SessionDirectorySelectionDialog()
+        assert sdsd is not None
+
+    def test_select_session_directory_label_when_app_name_not_set(self):
+        sdsd = SessionDirectorySelectionDialog()
+
+        self.assertEqual(sdsd.getWidget("select_session_directory").text(), "Select a session directory to save and retrieve all Sessions:")
+
+    def test_select_session_directory_label_when_app_name_set(self):
+        sdsd = SessionDirectorySelectionDialog(app_name="Test App")
+
+        self.assertEqual(sdsd.getWidget("select_session_directory").text(), "Select a session directory to save and retrieve all Test App Sessions:")
+
+    def test_browse_for_dir_button(self):
+        sdsd = SessionDirectorySelectionDialog()
+        # TODO: make test for this
+        sdsd.browse_for_dir()
+
+@unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
+class TestLoadSessionDialog(unittest.TestCase):
+    def test_init(self):
+        lsd = LoadSessionDialog()
+        assert lsd is not None
+
+    def test_init_with_title_param(self):
+        title = "Test Load Session Dialog Title"
+        lsd = LoadSessionDialog(title=title)
+        self.assertEqual(lsd.windowTitle(), title)
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_SessionDialogs.py
+++ b/test/test_SessionDialogs.py
@@ -11,7 +11,7 @@ else:
     skip_as_conda_build = False
 
 
-print ("skip_as_conda_build is set to ", skip_as_conda_build)
+print("skip_as_conda_build is set to ", skip_as_conda_build)
 
 if not skip_as_conda_build:
     if not QApplication.instance():
@@ -20,6 +20,7 @@ if not skip_as_conda_build:
         app = QApplication.instance()
 else:
     skip_test = True
+
 
 @unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestWarningDialog(unittest.TestCase):
@@ -32,10 +33,12 @@ class TestWarningDialog(unittest.TestCase):
         window_title = "Test Warning Dialog Title"
         detailed_text = "This is a test detailed text"
 
-        wd = WarningDialog(message=message, window_title=window_title, detailed_text=detailed_text)
+        wd = WarningDialog(
+            message=message, window_title=window_title, detailed_text=detailed_text)
         self.assertEqual(wd.detailedText(), detailed_text)
         self.assertEqual(wd.text(), message)
         self.assertEqual(wd.windowTitle(), window_title)
+
 
 @unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestErrorDialog(unittest.TestCase):
@@ -48,10 +51,12 @@ class TestErrorDialog(unittest.TestCase):
         window_title = "Test Error Dialog Title"
         detailed_text = "This is a test detailed text"
 
-        ed = ErrorDialog(message=message, window_title=window_title, detailed_text=detailed_text)
+        ed = ErrorDialog(
+            message=message, window_title=window_title, detailed_text=detailed_text)
         self.assertEqual(ed.detailedText(), detailed_text)
         self.assertEqual(ed.text(), message)
         self.assertEqual(ed.windowTitle(), window_title)
+
 
 @unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestSaveSessionDialog(unittest.TestCase):
@@ -64,6 +69,7 @@ class TestSaveSessionDialog(unittest.TestCase):
         ssd = SaveSessionDialog(title=title)
         self.assertEqual(ssd.windowTitle(), title)
 
+
 @unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestSessionDirectorySelectionDialog(unittest.TestCase):
     def test_init(self):
@@ -73,12 +79,14 @@ class TestSessionDirectorySelectionDialog(unittest.TestCase):
     def test_select_session_directory_label_when_app_name_not_set(self):
         sdsd = SessionDirectorySelectionDialog()
 
-        self.assertEqual(sdsd.getWidget("select_session_directory").text(), "Select a session directory to save and retrieve all Sessions:")
+        self.assertEqual(sdsd.getWidget("select_session_directory").text(
+        ), "Select a session directory to save and retrieve all Sessions:")
 
     def test_select_session_directory_label_when_app_name_set(self):
         sdsd = SessionDirectorySelectionDialog(app_name="Test App")
 
-        self.assertEqual(sdsd.getWidget("select_session_directory").text(), "Select a session directory to save and retrieve all Test App Sessions:")
+        self.assertEqual(sdsd.getWidget("select_session_directory").text(
+        ), "Select a session directory to save and retrieve all Test App Sessions:")
 
     @patch("PySide2.QtWidgets.QFileDialog.getExistingDirectory")
     def test_browse_for_dir_button_makes_file_dialog_for_getting_dir(self, mock_dialog_call):
@@ -91,7 +99,7 @@ class TestSessionDirectorySelectionDialog(unittest.TestCase):
         sdsd = SessionDirectorySelectionDialog()
         sdsd.browse_for_dir = unittest.mock.Mock()
         QFileDialog.getExistingDirectory = unittest.mock.Mock()
-        sdsd.getWidget("selected_dir").click()   
+        sdsd.getWidget("selected_dir").click()
         sdsd.browse_for_dir.assert_called_once()
 
     def test_browse_dialog_updates_session_directory_label(self):
@@ -100,7 +108,8 @@ class TestSessionDirectorySelectionDialog(unittest.TestCase):
         QFileDialog.getExistingDirectory = unittest.mock.Mock()
         QFileDialog.getExistingDirectory.return_value = example_dir
         sdsd.browse_for_dir()
-        self.assertEqual(sdsd.getWidget("selected_dir", "label").text(), os.path.basename(example_dir))
+        self.assertEqual(sdsd.getWidget(
+            "selected_dir", "label").text(), os.path.basename(example_dir))
 
     def test_browse_dialog_updates_selected_dir_attribute(self):
         example_dir = "C:\\Users\\test_user\\Documents\\test_dir"
@@ -109,6 +118,7 @@ class TestSessionDirectorySelectionDialog(unittest.TestCase):
         QFileDialog.getExistingDirectory.return_value = example_dir
         sdsd.browse_for_dir()
         self.assertEqual(sdsd.selected_dir, example_dir)
+
 
 @unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestLoadSessionDialog(unittest.TestCase):
@@ -123,8 +133,11 @@ class TestLoadSessionDialog(unittest.TestCase):
 
     def test_init_with_location_of_session_files_param(self):
         location_of_session_files = "C:\\Users\\test_user\\Documents\\test_dir"
-        lsd = LoadSessionDialog(location_of_session_files=location_of_session_files)
-        self.assertEqual(lsd.getWidget("sessions_directory").text(), "Currently loading sessions from: C:\\Users\\test_user\\Documents\\test_dir")
+        lsd = LoadSessionDialog(
+            location_of_session_files=location_of_session_files)
+        self.assertEqual(lsd.getWidget("sessions_directory").text(
+        ), "Currently loading sessions from: C:\\Users\\test_user\\Documents\\test_dir")
+
 
 @unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestAppSettingsDialog(unittest.TestCase):

--- a/test/test_SessionMainWindow.py
+++ b/test/test_SessionMainWindow.py
@@ -1,0 +1,547 @@
+import os
+import shutil
+import sys
+import unittest
+from datetime import datetime
+from unittest import mock
+from unittest.mock import patch
+
+from PySide2.QtCore import QSettings, QThreadPool
+from PySide2.QtWidgets import QApplication, QFileDialog, QMenu, QMenuBar
+
+import eqt
+from eqt.ui.SessionDialogs import (ErrorDialog, LoadSessionDialog,
+                                   SaveSessionDialog,
+                                   SessionDirectorySelectionDialog,
+                                   WarningDialog)
+from eqt.ui.SessionMainWindow import SessionMainWindow
+from eqt.io import zip_directory
+import json
+
+# skip the tests on GitHub actions
+if os.environ.get('CONDA_BUILD', '0') == '1':
+    skip_as_conda_build = True
+else:
+    skip_as_conda_build = False
+
+
+print ("skip_as_conda_build is set to ", skip_as_conda_build)
+
+if not skip_as_conda_build:
+    app = QApplication(sys.argv)
+else:
+    skip_test = True
+
+@unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
+class TestSessionMainWindowInit(unittest.TestCase):
+    '''
+    Tests the init method of the SessionMainWindow class
+    '''
+
+    def setUp(self):
+        # Testing the init method, so don't call init in the setUp
+        self.title = "title"
+        self.app_name = "App Name"
+
+
+    def test_init_sets_title_and_app_name(self):
+        smw = SessionMainWindow(self.title, self.app_name)
+        assert smw is not None
+        self.assertEqual(smw.windowTitle(), "title")
+        self.assertEqual(smw.app_name, "App Name")
+
+    def test_init_creates_threadpool(self):
+        smw = SessionMainWindow(self.title, self.app_name)
+        assert smw.threadpool is not None
+        assert(isinstance(smw.threadpool, QThreadPool))
+
+    def test_init_creates_settings(self):
+        smw = SessionMainWindow(self.title, self.app_name)
+        assert smw.settings is not None
+        assert(isinstance(smw.settings, QSettings))
+        self.assertEqual(smw.settings.organizationName(), self.title)
+        self.assertEqual(smw.settings.applicationName(), self.title)
+
+    def test_init_creates_settings_when_settings_name_given(self):
+        settings_name="settings_name"
+        smw = SessionMainWindow(self.title, self.app_name, settings_name)
+        assert smw.settings is not None
+        assert(isinstance(smw.settings, QSettings))
+        self.assertEqual(smw.settings.organizationName(), settings_name)
+        self.assertEqual(smw.settings.applicationName(), settings_name)
+
+    @patch('eqt.ui.SessionMainWindow.SessionMainWindow.setAppStyle')
+    def test_init_calls_setAppStyle(self, mock_setAppStyle):
+        smw = SessionMainWindow(self.title, self.app_name)
+        smw.setAppStyle.assert_called_once()
+
+    @patch('eqt.ui.SessionMainWindow.SessionMainWindow.createMenu')
+    def test_init_calls_createMenu(self, mock_menu_bar):  
+        smw = SessionMainWindow(self.title, self.app_name)     
+        assert smw.menu is not None
+        smw.createMenu.assert_called_once()
+
+    def test_sessions_directory_name_set(self):
+        smw = SessionMainWindow(self.title, self.app_name)
+        self.assertEqual(smw.sessions_directory_name, "App-Name-Sessions")
+    
+    def test_init_initialises_vars(self):
+        smw = SessionMainWindow(self.title, self.app_name)
+        self.assertEqual(smw.sessions_directory, None)
+        self.assertEqual(smw.should_really_close, False)
+        self.assertEqual(smw.progress_windows, {})
+
+    @patch('eqt.ui.SessionMainWindow.SessionMainWindow.setupSession')
+    def test_init_calls_setUpSession(self, mock_setupSession):
+        smw = SessionMainWindow(self.title, self.app_name)
+        smw.setupSession.assert_called_once()
+
+
+@unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
+class TestSessionMainWindowMenuBar(unittest.TestCase):
+    '''
+    Tests the expected menu bar is created
+    '''
+
+    def setUp(self):
+        self.title="title"
+        self.app_name="app_name"
+        self.smw = SessionMainWindow(self.title, self.app_name)
+
+    def test_createMenu_returns_QMenuBar(self):
+        assert self.smw.createMenu() is not None
+        assert isinstance(self.smw.createMenu(), QMenuBar)
+
+    def test_menu_has_file_and_settings_menu(self):
+        actions = self.smw.menu.actions()
+        assert actions[0].text() == "File"
+        assert actions[1].text() == "Settings"
+
+    def test_file_menu_has_expected_actions(self):
+        menus = self.smw.menu.findChildren(QMenu)
+        file_menu = menus[0]
+        assert file_menu.actions()[0].text() == "Save"
+        assert file_menu.actions()[1].text() == "Save + Exit"
+        assert file_menu.actions()[2].text() == "Exit"
+
+
+    def test_settings_menu_has_expected_actions(self):
+        menus = self.smw.menu.findChildren(QMenu)
+        settings_menu = menus[1]
+        self.assertEqual(settings_menu.actions()[0].text(), "Set Session Directory")
+
+
+@unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
+class TestSessionMainWindowSetupSession(unittest.TestCase):
+    '''
+    Tests the setupSession method of the SessionMainWindow class
+    
+    This method is responsible for setting up the session directory and session selector
+    '''
+
+    def setUp(self):
+        self.title="title"
+        self.app_name="app_name"
+        self.smw = SessionMainWindow(self.title, self.app_name)
+
+    def test_setupSession_when_sessions_folder_setting_is_None(self):
+        self.smw.settings = mock.MagicMock()
+        self.smw.createSessionsDirectorySelectionDialog = mock.MagicMock()
+        self.smw.createSessionSelector = mock.MagicMock()
+        self.smw.settings.value = mock.MagicMock(return_value=None)
+        self.smw.setupSession()
+        self.smw.createSessionsDirectorySelectionDialog.assert_called_once_with(new_session=True)
+        self.smw.createSessionSelector.assert_not_called()
+
+    def test_setupSession_when_sessions_folder_setting_is_not_None(self):
+        self.smw.settings = mock.MagicMock()
+        self.smw.createSessionsDirectorySelectionDialog = mock.MagicMock()
+        self.smw.createSessionSelector = mock.MagicMock()
+        session_folder_name = "session_folder_name"
+        os.mkdir(session_folder_name)
+        try:
+            self.smw.settings.value = mock.MagicMock(return_value=session_folder_name)
+            self.smw.setupSession()
+            self.smw.createSessionsDirectorySelectionDialog.assert_not_called()
+            self.smw.createSessionSelector.assert_called_once()
+            self.assertEqual(self.smw.sessions_directory, session_folder_name)
+            # Should have moved us into the session folder:
+            self.assertEqual(os.path.basename(os.getcwd()), session_folder_name)
+
+        except Exception as e:
+            raise e
+
+        finally:
+            if os.path.basename(os.getcwd()) == session_folder_name:
+                os.chdir("..")
+                os.rmdir(session_folder_name)
+                
+            else:
+                os.rmdir(session_folder_name)
+
+class TestSessionMainWindowCreateSessionSelector(unittest.TestCase):
+    '''
+    Tests the createSessionSelector method of the SessionMainWindow class
+    
+    This method is responsible for creating the session selector if any sessions exist,
+    or calling a method to create a new session if no sessions exist
+    '''
+    
+    def setUp(self):
+        self.title="title"
+        self.app_name="app_name"
+        self.smw = SessionMainWindow(self.title, self.app_name)
+        os.mkdir("Test Folder")
+        os.chdir("Test Folder")
+
+    def test_createSessionSelector_when_no_session_zips_exist(self):
+        self.smw.loadSessionNew = mock.MagicMock()
+        eqt.ui.SessionDialogs.LoadSessionDialog = mock.MagicMock()
+        self.smw.createSessionSelector()
+        self.smw.loadSessionNew.assert_called_once()
+        eqt.ui.SessionDialogs.LoadSessionDialog.assert_not_called()
+
+    def test_createSessionSelector_when_session_zips_exist(self):
+        # Make 2 zip files in the sessions directory:
+        shutil.make_archive("_session1_08-02-22", "zip")
+        shutil.make_archive("session_2_08-02-22", "zip")
+
+        zip_folders = ["_session1 08-02-22", "session_2 08-02-22"]
+
+        self.smw.createLoadSessionDialog = mock.MagicMock()
+        self.smw.loadSessionNew = mock.MagicMock()
+        self.smw.sessions_directory = mock.MagicMock()
+        self.smw.createSessionSelector()
+        self.smw.loadSessionNew.assert_not_called()
+
+        # We do not know which order the zip files will be returned in, so we need to check both orders:
+        try:
+            self.smw.createLoadSessionDialog.assert_called_once_with(zip_folders)
+        except AssertionError:
+            self.smw.createLoadSessionDialog.assert_called_once_with(zip_folders[::-1])
+
+    def tearDown(self):
+        os.chdir("..")
+        shutil.rmtree("Test Folder")
+
+class TestSessionMainWindowCreateLoadSessionDialog(unittest.TestCase):
+    '''
+    Tests the createLoadSessionDialog method of the SessionMainWindow class
+    
+    This method is responsible for creating the load session dialog
+    and populating it with the available sessions
+    '''
+
+    def setUp(self):
+        self.title="title"
+        self.app_name="app_name"
+        self.smw = SessionMainWindow(self.title, self.app_name)
+        self.smw.sessions_directory = mock.MagicMock()
+        self.zip_folders = ["zip_folder_1", "zip_folder_2"]
+
+    def test_createLoadSessionDialog_populates_session_dropdown(self):
+        dialog = self.smw.createLoadSessionDialog(self.zip_folders)
+        assert dialog is not None
+        assert isinstance(dialog, eqt.ui.SessionDialogs.LoadSessionDialog)
+        select_session_combo = dialog.getWidget('select_session')
+        assert select_session_combo is not None
+        items_in_combo = [select_session_combo.itemText(i) for i in range(select_session_combo.count())]
+        assert items_in_combo == self.zip_folders
+    
+    def test_createLoadSessionDialog_connections(self):
+        dialog = self.smw.createLoadSessionDialog(self.zip_folders)
+
+        self.smw.loadSessionLoad = mock.MagicMock()
+        self.smw.selectLoadSessionsDirectorySelectedInSessionSelector = mock.MagicMock()
+        self.smw.loadSessionNew = mock.MagicMock()
+
+        dialog = self.smw.createLoadSessionDialog(self.zip_folders)
+
+        dialog.Ok.click()
+        self.smw.loadSessionLoad.assert_called_once()
+
+        dialog.Select.click()
+        self.smw.selectLoadSessionsDirectorySelectedInSessionSelector.assert_called_with(dialog)
+
+        dialog.Cancel.click()
+        self.smw.loadSessionNew.assert_called_once()
+
+class TestSelectLoadSessionsDirectorySelectedInSessionSelector(unittest.TestCase):
+    '''
+    Tests the selectLoadSessionsDirectorySelectedInSessionSelector method of the SessionMainWindow class
+    
+    This method sould close the passed dialog, and call the createSessionsDirectorySelectionDialog method
+    with the new_session parameter set to True
+    '''
+
+    def setUp(self):
+        self.title="title"
+        self.app_name="app_name"
+        self.smw = SessionMainWindow(self.title, self.app_name)
+        self.load_session_dialog = mock.MagicMock()
+        self.load_session_dialog.close = mock.MagicMock()
+        self.smw.createSessionsDirectorySelectionDialog = mock.MagicMock()
+
+    def test_selectLoadSessionsDirectorySelectedInSessionSelector(self):
+        self.smw.selectLoadSessionsDirectorySelectedInSessionSelector(self.load_session_dialog)
+        assert self.load_session_dialog.close.called_once()
+        assert self.smw.createSessionsDirectorySelectionDialog.called_once_with(new_session=True)
+
+
+class TestCreateSessionFolder(unittest.TestCase):
+    '''
+    Tests the createSessionFolder method of the SessionMainWindow class
+    
+    This method is responsible for creating a folder for the session and moving into it
+    '''
+
+    def setUp(self):
+        self.title="title"
+        self.app_name="app_name"
+        
+        
+        self.smw = SessionMainWindow(self.title, self.app_name)
+
+        os.mkdir("Test Folder")
+        os.chdir("Test Folder")
+        self.date_time = datetime.now().strftime("%d-%m-%Y-%H-%M-%S")
+
+    def test_createSessionFolder(self):
+        session_folder_name = "app_name-" + self.date_time
+        self.smw.createSessionFolder()
+        self.assertEqual(os.path.basename(os.getcwd()), session_folder_name)
+
+    def tearDown(self):
+        os.chdir("..")
+        try:
+            shutil.rmtree("Test Folder")
+        except:
+            os.chdir("..")
+            shutil.rmtree("Test Folder")
+
+class TestLoadSessionConfig(unittest.TestCase):
+    '''
+    Tests the loadSessionConfig method of the SessionMainWindow class
+    
+    This method is responsible for unzipping a session folder and saving the contents of the .json session file to
+    SessionMainWindow.config.
+    '''
+
+    def setUp(self):
+        '''
+        Create a session zip file, which contains a session.json file'''
+        self.title="title"
+        self.app_name="app_name"
+        self.smw = SessionMainWindow(self.title, self.app_name)
+        self.session_folder = "app name 01-01-2020-00-00-00"
+
+        self.config = {'test_key': 'test_value', 'test_key2': 'test_value2',
+            'test_int_key': 1, 'test_float_key': 1.0, 'test_bool_key': True,
+            'test_list_key': [1, 2, 3], 'test_dict_key': {'test_key': 'test_value'}}
+
+        import json
+
+        os.mkdir("Test Folder")
+        os.chdir("Test Folder")
+        os.mkdir(self.session_folder)
+
+        session_file = os.path.join(self.session_folder, "session.json")
+        with open(session_file, "w+") as f:
+            json.dump(self.config, f)
+
+    def test_loadSessionConfig(self):
+        zip_directory(self.session_folder, compress=False)
+        self.smw.loadSessionConfig(self.session_folder)
+        self.assertEqual(self.config, self.smw.config)
+
+    def tearDown(self):
+        os.chdir("..")
+        try:
+            shutil.rmtree("Test Folder")
+        except:
+            os.chdir("..")
+            shutil.rmtree("Test Folder")
+
+
+class TestSaveSession(unittest.TestCase):
+    '''
+    Tests:
+    - saveSession method of the SessionMainWindow class
+    - moveSessionFolder method of the SessionMainWindow class
+    - saveSessionConfigToJson method of the SessionMainWindow class
+    
+    '''
+
+    def setUp(self):
+        self.title="title"
+        self.app_name="app_name"
+        self.smw = SessionMainWindow(self.title, self.app_name)
+        self.session_name = self.app_name
+
+
+    @mock.patch('eqt.ui.SessionMainWindow.zip_directory')
+    def test_saveSession(self, mock_zip_directory):
+        self.smw.moveSessionFolder = mock.MagicMock()
+        self.smw.saveSessionConfigToJson = mock.MagicMock()
+        self.smw.current_session_folder = mock.MagicMock()
+        self.smw.saveSession(self.session_name, compress=False)
+        self.smw.moveSessionFolder.assert_called_once_with(self.session_name)
+        self.smw.saveSessionConfigToJson.assert_called_once()
+        mock_zip_directory.assert_called_once_with(self.smw.current_session_folder, False)
+
+    def test_moveSessionFolder(self):
+        os.mkdir("Test Folder")
+        os.chdir("Test Folder")
+        new_folder_to_save_to = self.session_name + "_" + datetime.now().strftime("%d-%m-%Y-%H-%M")
+
+        # Make the current session folder, with a test file inside it:
+        
+        self.smw.sessions_directory = os.getcwd()
+        os.mkdir("Current Session Folder")
+        # Write file inside the folder:
+        with open(os.path.join("Current Session Folder", "test_file.txt"), "w+") as f:
+            f.write("test")
+        os.chdir("Current Session Folder")
+        self.smw.current_session_folder = os.getcwd()
+
+        try:
+            self.smw.moveSessionFolder(self.session_name)
+            self.assertEqual(os.path.basename(self.smw.current_session_folder), new_folder_to_save_to)
+            self.assertTrue(os.path.exists(new_folder_to_save_to))
+            self.assertTrue(os.path.exists(os.path.join(new_folder_to_save_to, "test_file.txt")))
+            self.assertFalse(os.path.exists("Current Session Folder"))
+            self.assertFalse(os.path.exists(os.path.join("Current Session Folder", "test_file.txt")))
+
+        except Exception as e:
+            raise e
+
+        finally:
+            os.chdir("..")
+            try:
+                shutil.rmtree("Test Folder")
+            except:
+                os.chdir("..")
+                shutil.rmtree("Test Folder")
+
+    def test_saveSessionConfigToJson(self):
+
+        self.config = {'test_key': 'test_value', 'test_key2': 'test_value2',
+            'test_int_key': 1, 'test_float_key': 1.0, 'test_bool_key': True,
+            'test_list_key': [1, 2, 3], 'test_dict_key': {'test_key': 'test_value'}}
+
+        config = {}
+        config.update(self.config)
+
+        # datetime gets added in the saveSessionConfigToJson method:
+        self.config['datetime'] = datetime.now().strftime("%d-%m-%Y-%H-%M")
+        
+        self.smw.getSessionConfig = mock.MagicMock(return_value=config)
+
+        os.mkdir("Test Folder")
+        os.chdir("Test Folder")
+        self.smw.current_session_folder = "."
+        try:
+            self.smw.saveSessionConfigToJson()
+            session_file = os.path.join(os.getcwd(), "session.json")
+            with open(session_file, "r") as f:
+                config = json.load(f)
+            self.assertEqual(config, self.config)
+            print(config)
+        except Exception as e:
+            raise e
+        finally:
+            os.chdir("..")
+            shutil.rmtree("Test Folder")
+        
+
+class TestRemoveTempMethods(unittest.TestCase):
+    '''
+    Tests:
+    - removeTempAndClose method of the SessionMainWindow class
+    - removeTemp method of the SessionMainWindow class
+    '''
+
+    def setUp(self):
+        self.title="title"
+        self.app_name="app_name"
+        self.smw = SessionMainWindow(self.title, self.app_name)
+        
+    def test_removeTemp_when_current_session_folder_exists(self):
+        try:
+            self.smw.current_session_folder = "Test Session Folder"
+            os.mkdir(self.smw.current_session_folder)
+            self.smw.removeTemp()
+            self.assertFalse(os.path.exists(self.smw.current_session_folder))
+        except Exception as e:
+            try:
+                shutil.rmtree(self.smw.current_session_folder)
+            except:
+                pass
+            raise e
+
+    def test_removeTemp_when_current_session_folder_does_not_exist(self):
+        self.smw.current_session_folder = "Test Session Folder"
+        self.smw.removeTemp()
+
+    def test_removeTemp_when_current_session_folder_exists_and_working_dir_is_it(self):
+        try:
+            self.smw.current_session_folder = "Test Session Folder"
+            os.mkdir(self.smw.current_session_folder)
+            os.chdir(self.smw.current_session_folder)
+            self.smw.removeTemp()
+        except Exception as e:
+            try:
+                os.chdir("..")
+                shutil.rmtree(self.smw.current_session_folder)
+            except:
+                pass
+            raise e
+    
+    def test_removeTemp_when_current_session_folder_exists(self):
+        try:
+            self.smw.current_session_folder = "Test Session Folder"
+            os.mkdir(self.smw.current_session_folder)
+            self.smw.removeTemp()
+            self.assertFalse(os.path.exists(self.smw.current_session_folder))
+        except Exception as e:
+            try:
+                shutil.rmtree(self.smw.current_session_folder)
+            except:
+                pass
+            raise e
+
+    def test_removeTempAndClose(self):
+        process_name = "Test Process"
+        self.smw.removeTemp = mock.MagicMock()
+        self.smw.close = mock.MagicMock()
+        self.smw.finishProcess = mock.MagicMock()
+        self.smw.should_really_close = False
+        self.smw.removeTempAndClose(process_name)
+        self.smw.removeTemp.assert_called_once()
+        self.smw.finishProcess.assert_called_once_with(process_name)
+        self.smw.close.assert_called_once()
+
+
+            
+            
+
+
+  
+
+
+
+
+
+            
+
+
+      
+
+    
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+

--- a/test/test_SessionMainWindow.py
+++ b/test/test_SessionMainWindow.py
@@ -496,19 +496,6 @@ class TestRemoveTempMethods(unittest.TestCase):
             except:
                 pass
             raise e
-    
-    def test_removeTemp_when_current_session_folder_exists(self):
-        try:
-            self.smw.current_session_folder = "Test Session Folder"
-            os.mkdir(self.smw.current_session_folder)
-            self.smw.removeTemp()
-            self.assertFalse(os.path.exists(self.smw.current_session_folder))
-        except Exception as e:
-            try:
-                shutil.rmtree(self.smw.current_session_folder)
-            except:
-                pass
-            raise e
 
     def test_removeTempAndClose(self):
         process_name = "Test Process"

--- a/test/test_SessionMainWindow.py
+++ b/test/test_SessionMainWindow.py
@@ -525,6 +525,9 @@ class TestRemoveTempMethods(unittest.TestCase):
         self.smw.finishProcess.assert_called_once_with(process_name)
         self.smw.close.assert_called_once()
 
+if __name__ == "__main__":
+    unittest.main()
+
 
             
             

--- a/test/test_SessionMainWindow.py
+++ b/test/test_SessionMainWindow.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import sys
@@ -7,16 +8,11 @@ from unittest import mock
 from unittest.mock import patch
 
 from PySide2.QtCore import QSettings, QThreadPool
-from PySide2.QtWidgets import QApplication, QFileDialog, QMenu, QMenuBar
+from PySide2.QtWidgets import QApplication,QMenu, QMenuBar
 
 import eqt
-from eqt.ui.SessionDialogs import (ErrorDialog, LoadSessionDialog,
-                                   SaveSessionDialog,
-                                   SessionDirectorySelectionDialog,
-                                   WarningDialog)
-from eqt.ui.SessionMainWindow import SessionMainWindow
 from eqt.io import zip_directory
-import json
+from eqt.ui.SessionMainWindow import SessionMainWindow
 
 # skip the tests on GitHub actions
 if os.environ.get('CONDA_BUILD', '0') == '1':
@@ -524,28 +520,6 @@ class TestRemoveTempMethods(unittest.TestCase):
         self.smw.removeTemp.assert_called_once()
         self.smw.finishProcess.assert_called_once_with(process_name)
         self.smw.close.assert_called_once()
-
-if __name__ == "__main__":
-    unittest.main()
-
-
-            
-            
-
-
-  
-
-
-
-
-
-            
-
-
-      
-
-    
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_SessionMainWindow.py
+++ b/test/test_SessionMainWindow.py
@@ -314,7 +314,7 @@ class TestCreateSessionFolder(unittest.TestCase):
         os.chdir("..")
         try:
             shutil.rmtree("Test Folder")
-        except:
+        except Exception:
             os.chdir("..")
             shutil.rmtree("Test Folder")
 
@@ -339,8 +339,6 @@ class TestLoadSessionConfig(unittest.TestCase):
             'test_int_key': 1, 'test_float_key': 1.0, 'test_bool_key': True,
             'test_list_key': [1, 2, 3], 'test_dict_key': {'test_key': 'test_value'}}
 
-        import json
-
         os.mkdir("Test Folder")
         os.chdir("Test Folder")
         os.mkdir(self.session_folder)
@@ -358,7 +356,7 @@ class TestLoadSessionConfig(unittest.TestCase):
         os.chdir("..")
         try:
             shutil.rmtree("Test Folder")
-        except:
+        except Exception:
             os.chdir("..")
             shutil.rmtree("Test Folder")
 
@@ -419,7 +417,7 @@ class TestSaveSession(unittest.TestCase):
             os.chdir("..")
             try:
                 shutil.rmtree("Test Folder")
-            except:
+            except Exception:
                 os.chdir("..")
                 shutil.rmtree("Test Folder")
 
@@ -475,7 +473,7 @@ class TestRemoveTempMethods(unittest.TestCase):
         except Exception as e:
             try:
                 shutil.rmtree(self.smw.current_session_folder)
-            except:
+            except Exception:
                 pass
             raise e
 
@@ -493,7 +491,7 @@ class TestRemoveTempMethods(unittest.TestCase):
             try:
                 os.chdir("..")
                 shutil.rmtree(self.smw.current_session_folder)
-            except:
+            except Exception:
                 pass
             raise e
 

--- a/test/test_SessionMainWindow.py
+++ b/test/test_SessionMainWindow.py
@@ -179,6 +179,7 @@ class TestSessionMainWindowSetupSession(unittest.TestCase):
             else:
                 os.rmdir(session_folder_name)
 
+@unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestSessionMainWindowCreateSessionSelector(unittest.TestCase):
     '''
     Tests the createSessionSelector method of the SessionMainWindow class
@@ -224,6 +225,7 @@ class TestSessionMainWindowCreateSessionSelector(unittest.TestCase):
         os.chdir("..")
         shutil.rmtree("Test Folder")
 
+@unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestSessionMainWindowCreateLoadSessionDialog(unittest.TestCase):
     '''
     Tests the createLoadSessionDialog method of the SessionMainWindow class
@@ -266,6 +268,7 @@ class TestSessionMainWindowCreateLoadSessionDialog(unittest.TestCase):
         dialog.Cancel.click()
         self.smw.loadSessionNew.assert_called_once()
 
+@unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestSelectLoadSessionsDirectorySelectedInSessionSelector(unittest.TestCase):
     '''
     Tests the selectLoadSessionsDirectorySelectedInSessionSelector method of the SessionMainWindow class
@@ -287,7 +290,7 @@ class TestSelectLoadSessionsDirectorySelectedInSessionSelector(unittest.TestCase
         assert self.load_session_dialog.close.called_once()
         assert self.smw.createSessionsDirectorySelectionDialog.called_once_with(new_session=True)
 
-
+@unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestCreateSessionFolder(unittest.TestCase):
     '''
     Tests the createSessionFolder method of the SessionMainWindow class
@@ -319,6 +322,7 @@ class TestCreateSessionFolder(unittest.TestCase):
             os.chdir("..")
             shutil.rmtree("Test Folder")
 
+@unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestLoadSessionConfig(unittest.TestCase):
     '''
     Tests the loadSessionConfig method of the SessionMainWindow class
@@ -362,7 +366,7 @@ class TestLoadSessionConfig(unittest.TestCase):
             os.chdir("..")
             shutil.rmtree("Test Folder")
 
-
+@unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestSaveSession(unittest.TestCase):
     '''
     Tests:
@@ -453,7 +457,7 @@ class TestSaveSession(unittest.TestCase):
             os.chdir("..")
             shutil.rmtree("Test Folder")
         
-
+@unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestRemoveTempMethods(unittest.TestCase):
     '''
     Tests:

--- a/test/test_SessionMainWindow.py
+++ b/test/test_SessionMainWindow.py
@@ -54,15 +54,15 @@ class TestSessionMainWindowInit(unittest.TestCase):
         smw = SessionMainWindow(self.title, self.app_name)
         assert smw.settings is not None
         assert(isinstance(smw.settings, QSettings))
-        self.assertEqual(smw.settings.organizationName(), self.title)
-        self.assertEqual(smw.settings.applicationName(), self.title)
+        self.assertEqual(smw.settings.organizationName(), self.app_name)
+        self.assertEqual(smw.settings.applicationName(), self.app_name)
 
     def test_init_creates_settings_when_settings_name_given(self):
         settings_name="settings_name"
         smw = SessionMainWindow(self.title, self.app_name, settings_name)
         assert smw.settings is not None
         assert(isinstance(smw.settings, QSettings))
-        self.assertEqual(smw.settings.organizationName(), settings_name)
+        self.assertEqual(smw.settings.organizationName(), self.app_name)
         self.assertEqual(smw.settings.applicationName(), settings_name)
 
     @patch('eqt.ui.SessionMainWindow.SessionMainWindow.setAppStyle')

--- a/test/test_SessionMainWindow.py
+++ b/test/test_SessionMainWindow.py
@@ -20,7 +20,6 @@ if os.environ.get('CONDA_BUILD', '0') == '1':
 else:
     skip_as_conda_build = False
 
-
 print ("skip_as_conda_build is set to ", skip_as_conda_build)
 
 if not skip_as_conda_build:
@@ -71,7 +70,7 @@ class TestSessionMainWindowInit(unittest.TestCase):
         smw = SessionMainWindow(self.title, self.app_name)
         smw.setAppStyle.assert_called_once()
 
-    @patch('eqt.ui.SessionMainWindow.SessionMainWindow.createMenu', return_value=(QMenuBar(), {}))
+    @patch('eqt.ui.SessionMainWindow.SessionMainWindow.createMenu', return_value=(1, {}))
     def test_init_calls_createMenu(self, mock_menu_bar):  
         smw = SessionMainWindow(self.title, self.app_name)     
         assert smw.menu_bar is not None
@@ -503,8 +502,6 @@ class TestRemoveTempMethods(unittest.TestCase):
         self.smw.finishProcess.assert_called_once_with(process_name)
         self.smw.close.assert_called_once()
 
-if __name__ == "__main__":
-    unittest.main()
 
 
 

--- a/test/test_SessionMainWindow.py
+++ b/test/test_SessionMainWindow.py
@@ -105,15 +105,20 @@ class TestSessionMainWindowMenuBar(unittest.TestCase):
         self.app_name="app_name"
         self.smw = SessionMainWindow(self.title, self.app_name)
 
-    def test_createMenu_returns_QMenuBar_and_dict(self):
-        assert self.smw.createMenu() is not None
-        assert isinstance(self.smw.createMenu()[0], QMenuBar)
-        assert isinstance(self.smw.createMenu()[1], dict)
+    def test_createMenu_sets_menu_bar_and_menus(self):
+        # first remove the menu bar and menus which are created in the init
+        del self.smw.menu_bar
+        del self.smw.menus
+        self.smw.createMenu()
+        assert hasattr(self.smw, "menu_bar")
+        assert hasattr(self.smw, "menus")
+        assert isinstance(self.smw.menu_bar, QMenuBar)
+        assert isinstance(self.smw.menus, dict)
         # dict should contain the expected menus
-        assert "File" in self.smw.createMenu()[1]
-        assert "Settings" in self.smw.createMenu()[1]
-        assert isinstance(self.smw.createMenu()[1]["File"], QMenu)
-        assert isinstance(self.smw.createMenu()[1]["Settings"], QMenu)
+        assert "File" in self.smw.menus
+        assert "Settings" in self.smw.menus
+        assert isinstance(self.smw.menus["File"], QMenu)
+        assert isinstance(self.smw.menus["Settings"], QMenu)
 
     def test_menu_has_file_and_settings_menu(self):
         actions = self.smw.menu_bar.actions()

--- a/test/test_SessionMainWindow.py
+++ b/test/test_SessionMainWindow.py
@@ -20,7 +20,7 @@ if os.environ.get('CONDA_BUILD', '0') == '1':
 else:
     skip_as_conda_build = False
 
-print ("skip_as_conda_build is set to ", skip_as_conda_build)
+print("skip_as_conda_build is set to ", skip_as_conda_build)
 
 if not skip_as_conda_build:
     if not QApplication.instance():
@@ -29,6 +29,8 @@ if not skip_as_conda_build:
         app = QApplication.instance()
 else:
     skip_test = True
+
+
 @unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestSessionMainWindowInit(unittest.TestCase):
     '''
@@ -40,7 +42,6 @@ class TestSessionMainWindowInit(unittest.TestCase):
         self.title = "title"
         self.app_name = "App Name"
 
-
     def test_init_sets_title_and_app_name(self):
         smw = SessionMainWindow(self.title, self.app_name)
         assert smw is not None
@@ -50,20 +51,20 @@ class TestSessionMainWindowInit(unittest.TestCase):
     def test_init_creates_threadpool(self):
         smw = SessionMainWindow(self.title, self.app_name)
         assert smw.threadpool is not None
-        assert(isinstance(smw.threadpool, QThreadPool))
+        assert (isinstance(smw.threadpool, QThreadPool))
 
     def test_init_creates_settings(self):
         smw = SessionMainWindow(self.title, self.app_name)
         assert smw.settings is not None
-        assert(isinstance(smw.settings, QSettings))
+        assert (isinstance(smw.settings, QSettings))
         self.assertEqual(smw.settings.organizationName(), self.app_name)
         self.assertEqual(smw.settings.applicationName(), self.app_name)
 
     def test_init_creates_settings_when_settings_name_given(self):
-        settings_name="settings_name"
+        settings_name = "settings_name"
         smw = SessionMainWindow(self.title, self.app_name, settings_name)
         assert smw.settings is not None
-        assert(isinstance(smw.settings, QSettings))
+        assert (isinstance(smw.settings, QSettings))
         self.assertEqual(smw.settings.organizationName(), self.app_name)
         self.assertEqual(smw.settings.applicationName(), settings_name)
 
@@ -73,15 +74,14 @@ class TestSessionMainWindowInit(unittest.TestCase):
         smw.setAppStyle.assert_called_once()
 
     @patch('eqt.ui.SessionMainWindow.SessionMainWindow.createMenu', return_value=(1, {}))
-    def test_init_calls_createMenu(self, mock_menu_bar):  
+    def test_init_calls_createMenu(self, mock_menu_bar):
         smw = SessionMainWindow(self.title, self.app_name)
         smw.createMenu.assert_called_once()
-        
 
     def test_sessions_directory_name_set(self):
         smw = SessionMainWindow(self.title, self.app_name)
         self.assertEqual(smw.sessions_directory_name, "App-Name-Sessions")
-    
+
     def test_init_initialises_vars(self):
         smw = SessionMainWindow(self.title, self.app_name)
         self.assertEqual(smw.sessions_directory, None)
@@ -101,8 +101,8 @@ class TestSessionMainWindowMenuBar(unittest.TestCase):
     '''
 
     def setUp(self):
-        self.title="title"
-        self.app_name="app_name"
+        self.title = "title"
+        self.app_name = "app_name"
         self.smw = SessionMainWindow(self.title, self.app_name)
 
     def test_createMenu_sets_menu_bar_and_menus(self):
@@ -132,25 +132,25 @@ class TestSessionMainWindowMenuBar(unittest.TestCase):
         assert file_menu.actions()[1].text() == "Save + Exit"
         assert file_menu.actions()[2].text() == "Exit"
 
-
     def test_settings_menu_has_expected_actions(self):
         menus = self.smw.menu_bar.findChildren(QMenu)
         settings_menu = menus[1]
         self.assertEqual(settings_menu.actions()[0].text(), "App Settings")
-        self.assertEqual(settings_menu.actions()[1].text(), "Set Session Directory")
+        self.assertEqual(settings_menu.actions()[
+                         1].text(), "Set Session Directory")
 
 
 @unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestSessionMainWindowSetupSession(unittest.TestCase):
     '''
     Tests the setupSession method of the SessionMainWindow class
-    
+
     This method is responsible for setting up the session directory and session selector
     '''
 
     def setUp(self):
-        self.title="title"
-        self.app_name="app_name"
+        self.title = "title"
+        self.app_name = "app_name"
         self.smw = SessionMainWindow(self.title, self.app_name)
 
     def test_setupSession_when_sessions_folder_setting_is_None(self):
@@ -159,7 +159,8 @@ class TestSessionMainWindowSetupSession(unittest.TestCase):
         self.smw.createSessionSelector = mock.MagicMock()
         self.smw.settings.value = mock.MagicMock(return_value=None)
         self.smw.setupSession()
-        self.smw.createSessionsDirectorySelectionDialog.assert_called_once_with(new_session=True)
+        self.smw.createSessionsDirectorySelectionDialog.assert_called_once_with(
+            new_session=True)
         self.smw.createSessionSelector.assert_not_called()
 
     def test_setupSession_when_sessions_folder_setting_is_not_None(self):
@@ -169,12 +170,12 @@ class TestSessionMainWindowSetupSession(unittest.TestCase):
         session_folder_name = "session_folder_name"
         os.mkdir(session_folder_name)
         try:
-            self.smw.settings.value = mock.MagicMock(return_value=session_folder_name)
+            self.smw.settings.value = mock.MagicMock(
+                return_value=session_folder_name)
             self.smw.setupSession()
             self.smw.createSessionsDirectorySelectionDialog.assert_not_called()
             self.smw.createSessionSelector.assert_called_once()
             self.assertEqual(self.smw.sessions_directory, session_folder_name)
-
 
         except Exception as e:
             raise e
@@ -183,22 +184,23 @@ class TestSessionMainWindowSetupSession(unittest.TestCase):
             if os.path.basename(os.getcwd()) == session_folder_name:
                 os.chdir("..")
                 os.rmdir(session_folder_name)
-                
+
             else:
                 os.rmdir(session_folder_name)
+
 
 @unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestSessionMainWindowCreateSessionSelector(unittest.TestCase):
     '''
     Tests the createSessionSelector method of the SessionMainWindow class
-    
+
     This method is responsible for creating the session selector if any sessions exist,
     or calling a method to create a new session if no sessions exist
     '''
-    
+
     def setUp(self):
-        self.title="title"
-        self.app_name="app_name"
+        self.title = "title"
+        self.app_name = "app_name"
         self.smw = SessionMainWindow(self.title, self.app_name)
         os.mkdir("Test Folder")
         os.chdir("Test Folder")
@@ -228,26 +230,29 @@ class TestSessionMainWindowCreateSessionSelector(unittest.TestCase):
 
         # We do not know which order the zip files will be returned in, so we need to check both orders:
         try:
-            self.smw.createLoadSessionDialog.assert_called_once_with(zip_folders)
+            self.smw.createLoadSessionDialog.assert_called_once_with(
+                zip_folders)
         except AssertionError:
-            self.smw.createLoadSessionDialog.assert_called_once_with(zip_folders[::-1])
+            self.smw.createLoadSessionDialog.assert_called_once_with(
+                zip_folders[::-1])
 
     def tearDown(self):
         os.chdir("..")
         shutil.rmtree("Test Folder")
 
+
 @unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestSessionMainWindowCreateLoadSessionDialog(unittest.TestCase):
     '''
     Tests the createLoadSessionDialog method of the SessionMainWindow class
-    
+
     This method is responsible for creating the load session dialog
     and populating it with the available sessions
     '''
 
     def setUp(self):
-        self.title="title"
-        self.app_name="app_name"
+        self.title = "title"
+        self.app_name = "app_name"
         self.smw = SessionMainWindow(self.title, self.app_name)
         self.smw.sessions_directory = mock.MagicMock()
         self.zip_folders = ["zip_folder_1", "zip_folder_2"]
@@ -258,9 +263,10 @@ class TestSessionMainWindowCreateLoadSessionDialog(unittest.TestCase):
         assert isinstance(dialog, eqt.ui.SessionDialogs.LoadSessionDialog)
         select_session_combo = dialog.getWidget('select_session')
         assert select_session_combo is not None
-        items_in_combo = [select_session_combo.itemText(i) for i in range(select_session_combo.count())]
+        items_in_combo = [select_session_combo.itemText(
+            i) for i in range(select_session_combo.count())]
         assert items_in_combo == self.zip_folders
-    
+
     def test_createLoadSessionDialog_connections(self):
         dialog = self.smw.createLoadSessionDialog(self.zip_folders)
 
@@ -274,46 +280,50 @@ class TestSessionMainWindowCreateLoadSessionDialog(unittest.TestCase):
         self.smw.loadSessionLoad.assert_called_once()
 
         dialog.Select.click()
-        self.smw.selectLoadSessionsDirectorySelectedInSessionSelector.assert_called_with(dialog)
+        self.smw.selectLoadSessionsDirectorySelectedInSessionSelector.assert_called_with(
+            dialog)
 
         dialog.Cancel.click()
         self.smw.loadSessionNew.assert_called_once()
+
 
 @unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestSelectLoadSessionsDirectorySelectedInSessionSelector(unittest.TestCase):
     '''
     Tests the selectLoadSessionsDirectorySelectedInSessionSelector method of the SessionMainWindow class
-    
+
     This method sould close the passed dialog, and call the createSessionsDirectorySelectionDialog method
     with the new_session parameter set to True
     '''
 
     def setUp(self):
-        self.title="title"
-        self.app_name="app_name"
+        self.title = "title"
+        self.app_name = "app_name"
         self.smw = SessionMainWindow(self.title, self.app_name)
         self.load_session_dialog = mock.MagicMock()
         self.load_session_dialog.close = mock.MagicMock()
         self.smw.createSessionsDirectorySelectionDialog = mock.MagicMock()
 
     def test_selectLoadSessionsDirectorySelectedInSessionSelector(self):
-        self.smw.selectLoadSessionsDirectorySelectedInSessionSelector(self.load_session_dialog)
+        self.smw.selectLoadSessionsDirectorySelectedInSessionSelector(
+            self.load_session_dialog)
         assert self.load_session_dialog.close.called_once()
-        assert self.smw.createSessionsDirectorySelectionDialog.called_once_with(new_session=True)
+        assert self.smw.createSessionsDirectorySelectionDialog.called_once_with(
+            new_session=True)
+
 
 @unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestCreateSessionFolder(unittest.TestCase):
     '''
     Tests the createSessionFolder method of the SessionMainWindow class
-    
+
     This method is responsible for creating a folder for the session and moving into it
     '''
 
     def setUp(self):
-        self.title="title"
-        self.app_name="app_name"
-        
-        
+        self.title = "title"
+        self.app_name = "app_name"
+
         self.smw = SessionMainWindow(self.title, self.app_name)
 
         os.mkdir("Test Folder")
@@ -337,7 +347,7 @@ class TestCreateSessionFolder(unittest.TestCase):
 class TestLoadSessionConfig(unittest.TestCase):
     '''
     Tests the loadSessionConfig method of the SessionMainWindow class
-    
+
     This method is responsible for unzipping a session folder and saving the contents of the .json session file to
     SessionMainWindow.config.
     '''
@@ -348,15 +358,16 @@ class TestLoadSessionConfig(unittest.TestCase):
         os.mkdir("Test Folder")
         os.chdir("Test Folder")
 
-        self.title="title"
-        self.app_name="app_name"
+        self.title = "title"
+        self.app_name = "app_name"
         self.smw = SessionMainWindow(self.title, self.app_name)
         self.smw.sessions_directory = "Sessions Folder"
-        self.session_folder = os.path.join(self.smw.sessions_directory, "app name 01-01-2020-00-00-00")
+        self.session_folder = os.path.join(
+            self.smw.sessions_directory, "app name 01-01-2020-00-00-00")
 
         self.config = {'test_key': 'test_value', 'test_key2': 'test_value2',
-            'test_int_key': 1, 'test_float_key': 1.0, 'test_bool_key': True,
-            'test_list_key': [1, 2, 3], 'test_dict_key': {'test_key': 'test_value'}}
+                       'test_int_key': 1, 'test_float_key': 1.0, 'test_bool_key': True,
+                       'test_list_key': [1, 2, 3], 'test_dict_key': {'test_key': 'test_value'}}
 
         os.mkdir(self.smw.sessions_directory)
         os.mkdir(self.session_folder)
@@ -378,6 +389,7 @@ class TestLoadSessionConfig(unittest.TestCase):
             os.chdir("..")
             shutil.rmtree("Test Folder")
 
+
 @unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestSaveSession(unittest.TestCase):
     '''
@@ -385,15 +397,14 @@ class TestSaveSession(unittest.TestCase):
     - saveSession method of the SessionMainWindow class
     - moveSessionFolder method of the SessionMainWindow class
     - saveSessionConfigToJson method of the SessionMainWindow class
-    
+
     '''
 
     def setUp(self):
-        self.title="title"
-        self.app_name="app_name"
+        self.title = "title"
+        self.app_name = "app_name"
         self.smw = SessionMainWindow(self.title, self.app_name)
         self.session_name = self.app_name
-
 
     @mock.patch('eqt.ui.SessionMainWindow.zip_directory')
     def test_saveSession(self, mock_zip_directory):
@@ -403,16 +414,19 @@ class TestSaveSession(unittest.TestCase):
         self.smw.saveSession(self.session_name, compress=False)
         self.smw.moveSessionFolder.assert_called_once_with(self.session_name)
         self.smw.saveSessionConfigToJson.assert_called_once()
-        mock_zip_directory.assert_called_once_with(self.smw.current_session_folder, False)
+        mock_zip_directory.assert_called_once_with(
+            self.smw.current_session_folder, False)
 
     def test_moveSessionFolder(self):
         os.mkdir("Test Folder")
-        new_folder_to_save_to = os.path.join("Test Folder", self.session_name + "_" + datetime.now().strftime("%d-%m-%Y-%H-%M"))
+        new_folder_to_save_to = os.path.join(
+            "Test Folder", self.session_name + "_" + datetime.now().strftime("%d-%m-%Y-%H-%M"))
 
         # Make the current session folder, with a test file inside it:
-        
+
         self.smw.sessions_directory = os.path.abspath("Test Folder")
-        current_session_folder = os.path.join(self.smw.sessions_directory, "Current Session Folder")
+        current_session_folder = os.path.join(
+            self.smw.sessions_directory, "Current Session Folder")
         os.mkdir(current_session_folder)
         # Write file inside the folder:
         with open(os.path.join(current_session_folder, "test_file.txt"), "w+") as f:
@@ -422,11 +436,14 @@ class TestSaveSession(unittest.TestCase):
 
         try:
             self.smw.moveSessionFolder(self.session_name)
-            self.assertEqual(os.path.abspath(self.smw.current_session_folder), os.path.abspath(new_folder_to_save_to))
+            self.assertEqual(os.path.abspath(
+                self.smw.current_session_folder), os.path.abspath(new_folder_to_save_to))
             self.assertTrue(os.path.exists(new_folder_to_save_to))
-            self.assertTrue(os.path.exists(os.path.join(new_folder_to_save_to, "test_file.txt")))
+            self.assertTrue(os.path.exists(os.path.join(
+                new_folder_to_save_to, "test_file.txt")))
             self.assertFalse(os.path.exists("Current Session Folder"))
-            self.assertFalse(os.path.exists(os.path.join("Current Session Folder", "test_file.txt")))
+            self.assertFalse(os.path.exists(os.path.join(
+                "Current Session Folder", "test_file.txt")))
 
         except Exception as e:
             raise e
@@ -437,15 +454,15 @@ class TestSaveSession(unittest.TestCase):
     def test_saveSessionConfigToJson(self):
 
         self.config = {'test_key': 'test_value', 'test_key2': 'test_value2',
-            'test_int_key': 1, 'test_float_key': 1.0, 'test_bool_key': True,
-            'test_list_key': [1, 2, 3], 'test_dict_key': {'test_key': 'test_value'}}
+                       'test_int_key': 1, 'test_float_key': 1.0, 'test_bool_key': True,
+                       'test_list_key': [1, 2, 3], 'test_dict_key': {'test_key': 'test_value'}}
 
         config = {}
         config.update(self.config)
 
         # datetime gets added in the saveSessionConfigToJson method:
         self.config['datetime'] = datetime.now().strftime("%d-%m-%Y-%H-%M")
-        
+
         self.smw.getSessionConfig = mock.MagicMock(return_value=config)
 
         os.mkdir("Test Folder")
@@ -462,7 +479,8 @@ class TestSaveSession(unittest.TestCase):
         finally:
             os.chdir("..")
             shutil.rmtree("Test Folder")
-        
+
+
 @unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestRemoveTempMethods(unittest.TestCase):
     '''
@@ -472,10 +490,10 @@ class TestRemoveTempMethods(unittest.TestCase):
     '''
 
     def setUp(self):
-        self.title="title"
-        self.app_name="app_name"
+        self.title = "title"
+        self.app_name = "app_name"
         self.smw = SessionMainWindow(self.title, self.app_name)
-        
+
     def test_removeTemp_when_current_session_folder_exists(self):
         try:
             self.smw.current_session_folder = "Test Session Folder"
@@ -504,7 +522,6 @@ class TestRemoveTempMethods(unittest.TestCase):
         self.smw.removeTemp.assert_called_once()
         self.smw.finishProcess.assert_called_once_with(process_name)
         self.smw.close.assert_called_once()
-
 
 
 if __name__ == "__main__":

--- a/test/test_SessionMainWindow.py
+++ b/test/test_SessionMainWindow.py
@@ -404,6 +404,10 @@ class TestSaveSession(unittest.TestCase):
 
         try:
             self.smw.moveSessionFolder(self.session_name)
+            # Method should move us into the new session directory:
+            self.assertEqual(os.getcwd(), os.path.join(self.smw.sessions_directory, new_folder_to_save_to))
+            # Move out of the folder, for testing:
+            os.chdir("..")
             self.assertEqual(os.path.basename(self.smw.current_session_folder), new_folder_to_save_to)
             self.assertTrue(os.path.exists(new_folder_to_save_to))
             self.assertTrue(os.path.exists(os.path.join(new_folder_to_save_to, "test_file.txt")))

--- a/test/test_SessionMainWindow.py
+++ b/test/test_SessionMainWindow.py
@@ -72,10 +72,11 @@ class TestSessionMainWindowInit(unittest.TestCase):
 
     @patch('eqt.ui.SessionMainWindow.SessionMainWindow.createMenu', return_value=(1, {}))
     def test_init_calls_createMenu(self, mock_menu_bar):  
-        smw = SessionMainWindow(self.title, self.app_name)     
+        smw = SessionMainWindow(self.title, self.app_name)
+        smw.createMenu.assert_called_once()     
         assert smw.menu_bar is not None
         assert smw.menus is not None
-        smw.createMenu.assert_called_once()
+        
 
     def test_sessions_directory_name_set(self):
         smw = SessionMainWindow(self.title, self.app_name)

--- a/test/test_SessionMainWindow.py
+++ b/test/test_SessionMainWindow.py
@@ -8,7 +8,7 @@ from unittest import mock
 from unittest.mock import patch
 
 from PySide2.QtCore import QSettings, QThreadPool
-from PySide2.QtWidgets import QApplication,QMenu, QMenuBar
+from PySide2.QtWidgets import QApplication, QMenu, QMenuBar
 
 import eqt
 from eqt.io import zip_directory
@@ -23,10 +23,12 @@ else:
 print ("skip_as_conda_build is set to ", skip_as_conda_build)
 
 if not skip_as_conda_build:
-    app = QApplication(sys.argv)
+    if not QApplication.instance():
+        app = QApplication(sys.argv)
+    else:
+        app = QApplication.instance()
 else:
     skip_test = True
-
 @unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestSessionMainWindowInit(unittest.TestCase):
     '''
@@ -73,9 +75,7 @@ class TestSessionMainWindowInit(unittest.TestCase):
     @patch('eqt.ui.SessionMainWindow.SessionMainWindow.createMenu', return_value=(1, {}))
     def test_init_calls_createMenu(self, mock_menu_bar):  
         smw = SessionMainWindow(self.title, self.app_name)
-        smw.createMenu.assert_called_once()     
-        assert smw.menu_bar is not None
-        assert smw.menus is not None
+        smw.createMenu.assert_called_once()
         
 
     def test_sessions_directory_name_set(self):

--- a/test/test_SessionMainWindow.py
+++ b/test/test_SessionMainWindow.py
@@ -71,10 +71,11 @@ class TestSessionMainWindowInit(unittest.TestCase):
         smw = SessionMainWindow(self.title, self.app_name)
         smw.setAppStyle.assert_called_once()
 
-    @patch('eqt.ui.SessionMainWindow.SessionMainWindow.createMenu')
+    @patch('eqt.ui.SessionMainWindow.SessionMainWindow.createMenu', return_value=(QMenuBar(), {}))
     def test_init_calls_createMenu(self, mock_menu_bar):  
         smw = SessionMainWindow(self.title, self.app_name)     
-        assert smw.menu is not None
+        assert smw.menu_bar is not None
+        assert smw.menus is not None
         smw.createMenu.assert_called_once()
 
     def test_sessions_directory_name_set(self):
@@ -104,17 +105,23 @@ class TestSessionMainWindowMenuBar(unittest.TestCase):
         self.app_name="app_name"
         self.smw = SessionMainWindow(self.title, self.app_name)
 
-    def test_createMenu_returns_QMenuBar(self):
+    def test_createMenu_returns_QMenuBar_and_dict(self):
         assert self.smw.createMenu() is not None
-        assert isinstance(self.smw.createMenu(), QMenuBar)
+        assert isinstance(self.smw.createMenu()[0], QMenuBar)
+        assert isinstance(self.smw.createMenu()[1], dict)
+        # dict should contain the expected menus
+        assert "File" in self.smw.createMenu()[1]
+        assert "Settings" in self.smw.createMenu()[1]
+        assert isinstance(self.smw.createMenu()[1]["File"], QMenu)
+        assert isinstance(self.smw.createMenu()[1]["Settings"], QMenu)
 
     def test_menu_has_file_and_settings_menu(self):
-        actions = self.smw.menu.actions()
+        actions = self.smw.menu_bar.actions()
         assert actions[0].text() == "File"
         assert actions[1].text() == "Settings"
 
     def test_file_menu_has_expected_actions(self):
-        menus = self.smw.menu.findChildren(QMenu)
+        menus = self.smw.menu_bar.findChildren(QMenu)
         file_menu = menus[0]
         assert file_menu.actions()[0].text() == "Save"
         assert file_menu.actions()[1].text() == "Save + Exit"
@@ -122,9 +129,10 @@ class TestSessionMainWindowMenuBar(unittest.TestCase):
 
 
     def test_settings_menu_has_expected_actions(self):
-        menus = self.smw.menu.findChildren(QMenu)
+        menus = self.smw.menu_bar.findChildren(QMenu)
         settings_menu = menus[1]
-        self.assertEqual(settings_menu.actions()[0].text(), "Set Session Directory")
+        self.assertEqual(settings_menu.actions()[0].text(), "App Settings")
+        self.assertEqual(settings_menu.actions()[1].text(), "Set Session Directory")
 
 
 @unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")

--- a/test/test_SessionMainWindow.py
+++ b/test/test_SessionMainWindow.py
@@ -474,8 +474,7 @@ class TestRemoveTempMethods(unittest.TestCase):
             try:
                 shutil.rmtree(self.smw.current_session_folder)
             except Exception:
-                pass
-            raise e
+                raise e
 
     def test_removeTemp_when_current_session_folder_does_not_exist(self):
         self.smw.current_session_folder = "Test Session Folder"

--- a/test/test_SessionMainWindow.py
+++ b/test/test_SessionMainWindow.py
@@ -481,20 +481,6 @@ class TestRemoveTempMethods(unittest.TestCase):
         self.smw.current_session_folder = "Test Session Folder"
         self.smw.removeTemp()
 
-    def test_removeTemp_when_current_session_folder_exists_and_working_dir_is_it(self):
-        try:
-            self.smw.current_session_folder = "Test Session Folder"
-            os.mkdir(self.smw.current_session_folder)
-            os.chdir(self.smw.current_session_folder)
-            self.smw.removeTemp()
-        except Exception as e:
-            try:
-                os.chdir("..")
-                shutil.rmtree(self.smw.current_session_folder)
-            except Exception:
-                pass
-            raise e
-
     def test_removeTempAndClose(self):
         process_name = "Test Process"
         self.smw.removeTemp = mock.MagicMock()

--- a/test/test__formUI_status_test.py
+++ b/test/test__formUI_status_test.py
@@ -22,7 +22,10 @@ print("skip_test is set to ", skip_test)
 
 
 if not skip_test:
-    app = QApplication(sys.argv)
+    if not QApplication.instance():
+        app = QApplication(sys.argv)
+    else:
+        app = QApplication.instance()
 else:
     skip_test = True
 

--- a/test/test__formUI_status_test.py
+++ b/test/test__formUI_status_test.py
@@ -9,8 +9,6 @@ from PySide2 import QtWidgets
 from PySide2.QtWidgets import QApplication
 from eqt.ui.UISliderWidget import UISliderWidget
 
-# TODO:
-# test using role names for retrieval vs normal names
 
 # skip the tests on GitHub actions
 if os.environ.get('CONDA_BUILD', '0') == '1':
@@ -40,17 +38,23 @@ def add_every_widget_to_form(form):
         The form to add the widgets to
     '''
     form.addWidget(QtWidgets.QLabel('test label'), 'Label: ', 'label')
-    form.addWidget(QtWidgets.QCheckBox('test checkbox'), 'CheckBox: ', 'checkBox')
+    form.addWidget(QtWidgets.QCheckBox(
+        'test checkbox'), 'CheckBox: ', 'checkBox')
     form.addWidget(QtWidgets.QComboBox(), 'ComboBox: ', 'comboBox')
-    form.addWidget(QtWidgets.QDoubleSpinBox(), 'DoubleSpinBox: ', 'doubleSpinBox')
+    form.addWidget(QtWidgets.QDoubleSpinBox(),
+                   'DoubleSpinBox: ', 'doubleSpinBox')
     form.addWidget(QtWidgets.QSpinBox(), 'SpinBox: ', 'spinBox')
     form.addWidget(QtWidgets.QSlider(), 'Slider: ', 'slider')
-    form.addWidget(UISliderWidget(QtWidgets.QLabel()), 'UISliderWidget: ', 'uiSliderWidget')
-    form.addWidget(QtWidgets.QRadioButton('test'), 'RadioButton: ', 'radioButton')
+    form.addWidget(UISliderWidget(QtWidgets.QLabel()),
+                   'UISliderWidget: ', 'uiSliderWidget')
+    form.addWidget(QtWidgets.QRadioButton('test'),
+                   'RadioButton: ', 'radioButton')
     form.addWidget(QtWidgets.QTextEdit('test'), 'TextEdit: ', 'textEdit')
-    form.addWidget(QtWidgets.QPlainTextEdit('test'), 'PlainTextEdit: ', 'plainTextEdit')
+    form.addWidget(QtWidgets.QPlainTextEdit('test'),
+                   'PlainTextEdit: ', 'plainTextEdit')
     form.addWidget(QtWidgets.QLineEdit('test'), 'LineEdit: ', 'lineEdit')
     form.addWidget(QtWidgets.QPushButton('test'), 'Button: ', 'button')
+
 
 def add_two_widgets_to_form(form):
     '''
@@ -62,7 +66,8 @@ def add_two_widgets_to_form(form):
         The form to add the widgets to
     '''
     form.addWidget(QtWidgets.QLabel('test label'), 'Label: ', 'label')
-    form.addWidget(QtWidgets.QCheckBox('test checkbox'), 'CheckBox: ', 'checkBox')
+    form.addWidget(QtWidgets.QCheckBox(
+        'test checkbox'), 'CheckBox: ', 'checkBox')
 
 
 @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
@@ -74,7 +79,7 @@ class FormDialogStatusTest(unittest.TestCase):
         add_every_widget_to_form(self.form)
         self.simple_form = FormDialog()
         add_two_widgets_to_form(self.simple_form)
-        
+
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_visibility(self):
         # Check that the visibility of the widget is saved to the state
@@ -82,95 +87,109 @@ class FormDialogStatusTest(unittest.TestCase):
         # to be True, because the FormDialog is not visible
         initial_label_visibility = True
         self.form.getWidget('label').isVisible = mock.MagicMock()
-        self.form.getWidget('label').isVisible.return_value = initial_label_visibility
-        
-        self.assertEqual(self.form.getWidgetState('label_field')['visible'], initial_label_visibility)
+        self.form.getWidget(
+            'label').isVisible.return_value = initial_label_visibility
+
+        self.assertEqual(self.form.getWidgetState('label_field')[
+                         'visible'], initial_label_visibility)
 
         final_label_visibility = False
         self.form.getWidget('label').isVisible.return_value = False
 
-        self.assertEqual(self.form.getWidgetState('label_field')['visible'], final_label_visibility)
+        self.assertEqual(self.form.getWidgetState('label_field')[
+                         'visible'], final_label_visibility)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_enabled_state(self):
         # Check that the enabled state of the widget is saved to the state
-        
+
         initial_label_enabled_state = True
-        
-        self.assertEqual(self.form.getWidgetState('label_field')['enabled'], initial_label_enabled_state)
+
+        self.assertEqual(self.form.getWidgetState('label_field')[
+                         'enabled'], initial_label_enabled_state)
 
         self.form.getWidget('label').setEnabled(False)
         final_label_enabled_state = False
 
-        self.assertEqual(self.form.getWidgetState('label_field')['enabled'], final_label_enabled_state)
+        self.assertEqual(self.form.getWidgetState('label_field')[
+                         'enabled'], final_label_enabled_state)
 
     # Test value is saved for all widget types ----------------------------------------------------------------
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QLabel_value(self):
         # Check that the value of the QLabel is saved to the state
-        
-        initial_label_value ='Label: '
-        
-        self.assertEqual(self.form.getWidgetState('label_label')['value'], initial_label_value)
+
+        initial_label_value = 'Label: '
+
+        self.assertEqual(self.form.getWidgetState(
+            'label_label')['value'], initial_label_value)
 
         final_label_value = 'final test label'
         self.form.getWidget('label', 'label').setText(final_label_value)
-        
-        self.assertEqual(self.form.getWidgetState('label_label')['value'], final_label_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'label_label')['value'], final_label_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_value_using_role_parameter_field(self):
         # Check that the value of the QLabel is saved to the state
-        
-        initial_label_value ='test label'
-        
-        self.assertEqual(self.form.getWidgetState('label', 'field')['value'], initial_label_value)
+
+        initial_label_value = 'test label'
+
+        self.assertEqual(self.form.getWidgetState(
+            'label', 'field')['value'], initial_label_value)
 
         final_label_value = 'final test label'
         self.form.getWidget('label').setText(final_label_value)
-        
-        self.assertEqual(self.form.getWidgetState('label','field')['value'], final_label_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'label', 'field')['value'], final_label_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_value_using_role_parameter_label(self):
         # Check that the value of the QLabel is saved to the state
-        
-        initial_label_value ='test label'
-        
-        self.assertEqual(self.form.getWidgetState('label', 'field')['value'], initial_label_value)
+
+        initial_label_value = 'test label'
+
+        self.assertEqual(self.form.getWidgetState(
+            'label', 'field')['value'], initial_label_value)
 
         final_label_value = 'final test label'
         self.form.getWidget('label').setText(final_label_value)
-        
-        self.assertEqual(self.form.getWidgetState('label','field')['value'], final_label_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'label', 'field')['value'], final_label_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_value_using_default_role_parameter(self):
         # Check that the value of the QLabel is saved to the state
-        initial_label_value ='test label'
-        
+        initial_label_value = 'test label'
+
         # In getWidgetState we do not specify if we want the 'field' or 'label' role, so it should default to 'field':
-        self.assertEqual(self.form.getWidgetState('label')['value'], initial_label_value)
+        self.assertEqual(self.form.getWidgetState(
+            'label')['value'], initial_label_value)
 
         final_label_value = 'final test label'
         self.form.getWidget('label').setText(final_label_value)
-        
-        self.assertEqual(self.form.getWidgetState('label')['value'], final_label_value)
 
+        self.assertEqual(self.form.getWidgetState(
+            'label')['value'], final_label_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QCheckBox_value(self):
         # Check that the value of the QCheckBox is saved to the state
-        
+
         initial_checkbox_value = False
-        
-        self.assertEqual(self.form.getWidgetState('checkBox_field')['value'], initial_checkbox_value)
+
+        self.assertEqual(self.form.getWidgetState('checkBox_field')[
+                         'value'], initial_checkbox_value)
 
         final_checkbox_value = True
         self.form.getWidget('checkBox').setChecked(final_checkbox_value)
-        
-        self.assertEqual(self.form.getWidgetState('checkBox_field')['value'], final_checkbox_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'checkBox_field')['value'], final_checkbox_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QComboBox_value(self):
@@ -178,139 +197,162 @@ class FormDialogStatusTest(unittest.TestCase):
 
         combobox_list = ['test', 'test2']
         self.form.getWidget('comboBox').addItems(combobox_list)
-        
+
         initial_combobox_value = 0
-        
-        self.assertEqual(self.form.getWidgetState('comboBox_field')['value'], initial_combobox_value)
+
+        self.assertEqual(self.form.getWidgetState('comboBox_field')[
+                         'value'], initial_combobox_value)
 
         final_combobox_value = 1
         self.form.getWidget('comboBox').setCurrentIndex(final_combobox_value)
-        
-        self.assertEqual(self.form.getWidgetState('comboBox_field')['value'], final_combobox_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'comboBox_field')['value'], final_combobox_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QDoubleSpinBox_value(self):
         # Check that the value of the QDoubleSpinBox is saved to the state
-        
+
         initial_doubleSpinBox_value = 0.0
-        
-        self.assertEqual(self.form.getWidgetState('doubleSpinBox_field')['value'], initial_doubleSpinBox_value)
+
+        self.assertEqual(self.form.getWidgetState('doubleSpinBox_field')[
+                         'value'], initial_doubleSpinBox_value)
 
         final_doubleSpinBox_value = 1.0
-        self.form.getWidget('doubleSpinBox').setValue(final_doubleSpinBox_value)
-        
-        self.assertEqual(self.form.getWidgetState('doubleSpinBox_field')['value'], final_doubleSpinBox_value)
+        self.form.getWidget('doubleSpinBox').setValue(
+            final_doubleSpinBox_value)
+
+        self.assertEqual(self.form.getWidgetState('doubleSpinBox_field')[
+                         'value'], final_doubleSpinBox_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QSpinBox_value(self):
         # Check that the value of the QSpinBox is saved to the state
-        
+
         initial_spinBox_value = 0
-        
-        self.assertEqual(self.form.getWidgetState('spinBox_field')['value'], initial_spinBox_value)
+
+        self.assertEqual(self.form.getWidgetState('spinBox_field')[
+                         'value'], initial_spinBox_value)
 
         final_spinBox_value = 1
         self.form.getWidget('spinBox').setValue(final_spinBox_value)
-        
-        self.assertEqual(self.form.getWidgetState('spinBox_field')['value'], final_spinBox_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'spinBox_field')['value'], final_spinBox_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QSlider_value(self):
         # Check that the value of the QSlider is saved to the state
-        
+
         initial_slider_value = 0
-        
-        self.assertEqual(self.form.getWidgetState('slider_field')['value'], initial_slider_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'slider_field')['value'], initial_slider_value)
 
         final_slider_value = 1
         self.form.getWidget('slider').setValue(final_slider_value)
-        
-        self.assertEqual(self.form.getWidgetState('slider_field')['value'], final_slider_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'slider_field')['value'], final_slider_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_UISliderWidget_value(self):
         # Check that the value of the UISliderWidget is returned in the state
-        
+
         initial_slider_value = 0
-        
-        self.assertEqual(self.form.getWidgetState('uiSliderWidget_field')['value'], initial_slider_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'uiSliderWidget_field')['value'], initial_slider_value)
 
         final_slider_value = 1
         self.form.getWidget('uiSliderWidget').setValue(final_slider_value)
-        
-        self.assertEqual(self.form.getWidgetState('uiSliderWidget_field')['value'], final_slider_value)
 
-    @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")    
+        self.assertEqual(self.form.getWidgetState(
+            'uiSliderWidget_field')['value'], final_slider_value)
+
+    @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QLineEdit_value(self):
         # Check that the value of the QLineEdit is saved to the state
-        
+
         initial_lineEdit_value = ''
         self.form.getWidget('lineEdit').setText(initial_lineEdit_value)
-        
-        self.assertEqual(self.form.getWidgetState('lineEdit_field')['value'], initial_lineEdit_value)
+
+        self.assertEqual(self.form.getWidgetState('lineEdit_field')[
+                         'value'], initial_lineEdit_value)
 
         final_lineEdit_value = 'test'
         self.form.getWidget('lineEdit').setText(final_lineEdit_value)
-        
-        self.assertEqual(self.form.getWidgetState('lineEdit_field')['value'], final_lineEdit_value)
 
-    @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")    
+        self.assertEqual(self.form.getWidgetState(
+            'lineEdit_field')['value'], final_lineEdit_value)
+
+    @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QTextEdit_value(self):
         # Check that the value of the QTextEdit is saved to the state
-        
+
         initial_textEdit_value = ''
         self.form.getWidget('textEdit').setText(initial_textEdit_value)
-        
-        self.assertEqual(self.form.getWidgetState('textEdit_field')['value'], initial_textEdit_value)
+
+        self.assertEqual(self.form.getWidgetState('textEdit_field')[
+                         'value'], initial_textEdit_value)
 
         final_textEdit_value = 'test'
         self.form.getWidget('textEdit').setText(final_textEdit_value)
-        
-        self.assertEqual(self.form.getWidgetState('textEdit_field')['value'], final_textEdit_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'textEdit_field')['value'], final_textEdit_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QPlainTextEdit_value(self):
         # Check that the value of the QPlainTextEdit is saved to the state
-        
+
         initial_plainTextEdit_value = ''
-        self.form.getWidget('plainTextEdit').setPlainText(initial_plainTextEdit_value)
-        
-        self.assertEqual(self.form.getWidgetState('plainTextEdit_field')['value'], initial_plainTextEdit_value)
+        self.form.getWidget('plainTextEdit').setPlainText(
+            initial_plainTextEdit_value)
+
+        self.assertEqual(self.form.getWidgetState('plainTextEdit_field')[
+                         'value'], initial_plainTextEdit_value)
 
         final_plainTextEdit_value = 'test'
-        self.form.getWidget('plainTextEdit').setPlainText(final_plainTextEdit_value)
-        
-        self.assertEqual(self.form.getWidgetState('plainTextEdit_field')['value'], final_plainTextEdit_value)
+        self.form.getWidget('plainTextEdit').setPlainText(
+            final_plainTextEdit_value)
+
+        self.assertEqual(self.form.getWidgetState('plainTextEdit_field')[
+                         'value'], final_plainTextEdit_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QPushButton_value(self):
         # Check that the value of the QPushButton is saved to the state
-        
+
         initial_button_value = False
-        
-        self.assertEqual(self.form.getWidgetState('button_field')['value'], initial_button_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'button_field')['value'], initial_button_value)
 
         final_button_value = True
         self.form.getWidget('button').setCheckable(True)
         self.form.getWidget('button').setChecked(final_button_value)
-        
-        self.assertEqual(self.form.getWidgetState('button_field')['value'], final_button_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'button_field')['value'], final_button_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QRadioButton_value(self):
         # Check that the value of the QRadioButton is saved to the state
-        
+
         initial_radio_value = False
-        
-        self.assertEqual(self.form.getWidgetState('radioButton_field')['value'], initial_radio_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'radioButton_field')['value'], initial_radio_value)
 
         final_radio_value = True
         self.form.getWidget('radioButton').setChecked(final_radio_value)
-        
-        self.assertEqual(self.form.getWidgetState('radioButton_field')['value'], final_radio_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'radioButton_field')['value'], final_radio_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
-    def test_applyWidgetStates(self):   
+    def test_applyWidgetStates(self):
         state_to_set = {
             'checkBox_field': {'value': True, 'enabled': False, 'visible': False},
             'label_field': {'value': 'applyWidgetStates Test', 'enabled': True, 'visible': False}
@@ -318,33 +360,41 @@ class FormDialogStatusTest(unittest.TestCase):
 
         self.simple_form.applyWidgetStates(state_to_set)
 
-        self.assertEqual(self.simple_form.getWidgetState('checkBox_field'), state_to_set['checkBox_field'])
-        self.assertEqual(self.simple_form.getWidgetState('label_field'), state_to_set['label_field'])
+        self.assertEqual(self.simple_form.getWidgetState(
+            'checkBox_field'), state_to_set['checkBox_field'])
+        self.assertEqual(self.simple_form.getWidgetState(
+            'label_field'), state_to_set['label_field'])
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_applyWidgetState(self):
         state_to_set = {'value': True, 'enabled': False, 'visible': False}
         self.simple_form.applyWidgetState('checkBox_field', state_to_set)
-        self.assertEqual(self.simple_form.getWidgetState('checkBox_field'), state_to_set)
+        self.assertEqual(self.simple_form.getWidgetState(
+            'checkBox_field'), state_to_set)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_applyWidgetState_using_role_parameter_field(self):
         state_to_set = {'value': True, 'enabled': False, 'visible': False}
-        self.simple_form.applyWidgetState('checkBox', state_to_set, role='field')
-        self.assertEqual(self.simple_form.getWidgetState('checkBox','field'), state_to_set)
+        self.simple_form.applyWidgetState(
+            'checkBox', state_to_set, role='field')
+        self.assertEqual(self.simple_form.getWidgetState(
+            'checkBox', 'field'), state_to_set)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_applyWidgetState_using_role_parameter_label(self):
-        state_to_set = {'value': 'test the checkbox:', 'enabled': False, 'visible': False}
-        self.simple_form.applyWidgetState('checkBox', state_to_set, role='label')
-        self.assertEqual(self.simple_form.getWidgetState('checkBox','label'), state_to_set)
+        state_to_set = {'value': 'test the checkbox:',
+                        'enabled': False, 'visible': False}
+        self.simple_form.applyWidgetState(
+            'checkBox', state_to_set, role='label')
+        self.assertEqual(self.simple_form.getWidgetState(
+            'checkBox', 'label'), state_to_set)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_applyWidgetState_using_role_parameter_default(self):
         state_to_set = {'value': True, 'enabled': False, 'visible': False}
         self.simple_form.applyWidgetState('checkBox', state_to_set)
-        self.assertEqual(self.simple_form.getWidgetState('checkBox'), state_to_set)
-
+        self.assertEqual(self.simple_form.getWidgetState(
+            'checkBox'), state_to_set)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getAllWidgetStates(self):
@@ -358,7 +408,6 @@ class FormDialogStatusTest(unittest.TestCase):
         }
 
         self.assertEqual(self.simple_form.getAllWidgetStates(), expected_state)
-
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_saveAllWidgetStates(self):
@@ -373,13 +422,14 @@ class FormDialogStatusTest(unittest.TestCase):
 
         self.simple_form.saveAllWidgetStates()
 
-        self.assertEqual(self.simple_form.formWidget.widget_states, expected_state)
+        self.assertEqual(
+            self.simple_form.formWidget.widget_states, expected_state)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_restoreAllSavedWidgetStates(self):
         # Check that the state of all widgets is restored from the state variable
 
-        state_to_restore= {
+        state_to_restore = {
             'checkBox_field': {'value': True, 'enabled': False, 'visible': False},
             'label_field': {'value': 'applyWidgetStates Test', 'enabled': True, 'visible': False},
             'checkBox_label': {'value': 'CheckBox Test: ', 'enabled': True, 'visible': False},
@@ -390,19 +440,30 @@ class FormDialogStatusTest(unittest.TestCase):
 
         self.simple_form.restoreAllSavedWidgetStates()
 
-        self.assertEqual(self.simple_form.getWidget('checkBox').isChecked(), state_to_restore['checkBox_field']['value'])
-        self.assertEqual(self.simple_form.getWidget('checkBox').isEnabled(), state_to_restore['checkBox_field']['enabled'])
-        self.assertEqual(self.simple_form.getWidget('checkBox').isVisible(), state_to_restore['checkBox_field']['visible'])
-        self.assertEqual(self.simple_form.getWidget('checkBox', 'label').text(), state_to_restore['checkBox_label']['value'])
-        self.assertEqual(self.simple_form.getWidget('checkBox', 'label').isEnabled(), state_to_restore['checkBox_label']['enabled'])
-        self.assertEqual(self.simple_form.getWidget('checkBox', 'label').isVisible(), state_to_restore['checkBox_label']['visible'])
-        self.assertEqual(self.simple_form.getWidget('label').text(), state_to_restore['label_field']['value'])
-        self.assertEqual(self.simple_form.getWidget('label').isEnabled(), state_to_restore['label_field']['enabled'])
-        self.assertEqual(self.simple_form.getWidget('label').isVisible(), state_to_restore['label_field']['visible'])
-        self.assertEqual(self.simple_form.getWidget('label', 'label').text(), state_to_restore['label_label']['value'])
-        self.assertEqual(self.simple_form.getWidget('label', 'label').isEnabled(), state_to_restore['label_label']['enabled'])
-        self.assertEqual(self.simple_form.getWidget('label', 'label').isVisible(), state_to_restore['label_label']['visible'])
-
+        self.assertEqual(self.simple_form.getWidget(
+            'checkBox').isChecked(), state_to_restore['checkBox_field']['value'])
+        self.assertEqual(self.simple_form.getWidget(
+            'checkBox').isEnabled(), state_to_restore['checkBox_field']['enabled'])
+        self.assertEqual(self.simple_form.getWidget(
+            'checkBox').isVisible(), state_to_restore['checkBox_field']['visible'])
+        self.assertEqual(self.simple_form.getWidget(
+            'checkBox', 'label').text(), state_to_restore['checkBox_label']['value'])
+        self.assertEqual(self.simple_form.getWidget(
+            'checkBox', 'label').isEnabled(), state_to_restore['checkBox_label']['enabled'])
+        self.assertEqual(self.simple_form.getWidget(
+            'checkBox', 'label').isVisible(), state_to_restore['checkBox_label']['visible'])
+        self.assertEqual(self.simple_form.getWidget(
+            'label').text(), state_to_restore['label_field']['value'])
+        self.assertEqual(self.simple_form.getWidget(
+            'label').isEnabled(), state_to_restore['label_field']['enabled'])
+        self.assertEqual(self.simple_form.getWidget(
+            'label').isVisible(), state_to_restore['label_field']['visible'])
+        self.assertEqual(self.simple_form.getWidget(
+            'label', 'label').text(), state_to_restore['label_label']['value'])
+        self.assertEqual(self.simple_form.getWidget(
+            'label', 'label').isEnabled(), state_to_restore['label_label']['enabled'])
+        self.assertEqual(self.simple_form.getWidget(
+            'label', 'label').isVisible(), state_to_restore['label_label']['visible'])
 
 
 @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
@@ -414,7 +475,7 @@ class FormWidgetStateTest(unittest.TestCase):
         add_every_widget_to_form(self.form)
         self.simple_form = FormWidget()
         add_two_widgets_to_form(self.simple_form)
-        
+
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_visibility(self):
         # Check that the visibility of the widget is saved to the state
@@ -422,94 +483,109 @@ class FormWidgetStateTest(unittest.TestCase):
         # to be True, because the FormDialog is not visible
         initial_label_visibility = True
         self.form.getWidget('label').isVisible = mock.MagicMock()
-        self.form.getWidget('label').isVisible.return_value = initial_label_visibility
-        
-        self.assertEqual(self.form.getWidgetState('label_field')['visible'], initial_label_visibility)
+        self.form.getWidget(
+            'label').isVisible.return_value = initial_label_visibility
+
+        self.assertEqual(self.form.getWidgetState('label_field')[
+                         'visible'], initial_label_visibility)
 
         final_label_visibility = False
         self.form.getWidget('label').isVisible.return_value = False
 
-        self.assertEqual(self.form.getWidgetState('label_field')['visible'], final_label_visibility)
+        self.assertEqual(self.form.getWidgetState('label_field')[
+                         'visible'], final_label_visibility)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_enabled_state(self):
         # Check that the enabled state of the widget is saved to the state
-        
+
         initial_label_enabled_state = True
-        
-        self.assertEqual(self.form.getWidgetState('label_field')['enabled'], initial_label_enabled_state)
+
+        self.assertEqual(self.form.getWidgetState('label_field')[
+                         'enabled'], initial_label_enabled_state)
 
         self.form.getWidget('label').setEnabled(False)
         final_label_enabled_state = False
 
-        self.assertEqual(self.form.getWidgetState('label_field')['enabled'], final_label_enabled_state)
+        self.assertEqual(self.form.getWidgetState('label_field')[
+                         'enabled'], final_label_enabled_state)
 
     # Test value is saved for all widget types ----------------------------------------------------------------
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_value_using_role_parameter_field(self):
         # Check that the value of the QLabel is saved to the state
-        
-        initial_label_value ='test label'
-        
-        self.assertEqual(self.form.getWidgetState('label', 'field')['value'], initial_label_value)
+
+        initial_label_value = 'test label'
+
+        self.assertEqual(self.form.getWidgetState(
+            'label', 'field')['value'], initial_label_value)
 
         final_label_value = 'final test label'
         self.form.getWidget('label').setText(final_label_value)
-        
-        self.assertEqual(self.form.getWidgetState('label','field')['value'], final_label_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'label', 'field')['value'], final_label_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_value_using_role_parameter_label(self):
         # Check that the value of the QLabel is saved to the state
-        
-        initial_label_value ='test label'
-        
-        self.assertEqual(self.form.getWidgetState('label', 'field')['value'], initial_label_value)
+
+        initial_label_value = 'test label'
+
+        self.assertEqual(self.form.getWidgetState(
+            'label', 'field')['value'], initial_label_value)
 
         final_label_value = 'final test label'
         self.form.getWidget('label').setText(final_label_value)
-        
-        self.assertEqual(self.form.getWidgetState('label','field')['value'], final_label_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'label', 'field')['value'], final_label_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_value_using_default_role_parameter(self):
         # Check that the value of the QLabel is saved to the state
-        initial_label_value ='test label'
-        
+        initial_label_value = 'test label'
+
         # In getWidgetState we do not specify if we want the 'field' or 'label' role, so it should default to 'field':
-        self.assertEqual(self.form.getWidgetState('label')['value'], initial_label_value)
+        self.assertEqual(self.form.getWidgetState(
+            'label')['value'], initial_label_value)
 
         final_label_value = 'final test label'
         self.form.getWidget('label').setText(final_label_value)
-        
-        self.assertEqual(self.form.getWidgetState('label')['value'], final_label_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'label')['value'], final_label_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QLabel_value(self):
         # Check that the value of the QLabel is saved to the state
-        
-        initial_label_value ='test label'
-        
-        self.assertEqual(self.form.getWidgetState('label_field')['value'], initial_label_value)
+
+        initial_label_value = 'test label'
+
+        self.assertEqual(self.form.getWidgetState(
+            'label_field')['value'], initial_label_value)
 
         final_label_value = 'final test label'
         self.form.getWidget('label').setText(final_label_value)
-        
-        self.assertEqual(self.form.getWidgetState('label_field')['value'], final_label_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'label_field')['value'], final_label_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QCheckBox_value(self):
         # Check that the value of the QCheckBox is saved to the state
-        
+
         initial_checkbox_value = False
-        
-        self.assertEqual(self.form.getWidgetState('checkBox_field')['value'], initial_checkbox_value)
+
+        self.assertEqual(self.form.getWidgetState('checkBox_field')[
+                         'value'], initial_checkbox_value)
 
         final_checkbox_value = True
         self.form.getWidget('checkBox').setChecked(final_checkbox_value)
-        
-        self.assertEqual(self.form.getWidgetState('checkBox_field')['value'], final_checkbox_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'checkBox_field')['value'], final_checkbox_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QComboBox_value(self):
@@ -517,139 +593,162 @@ class FormWidgetStateTest(unittest.TestCase):
 
         combobox_list = ['test', 'test2']
         self.form.getWidget('comboBox').addItems(combobox_list)
-        
+
         initial_combobox_value = 0
-        
-        self.assertEqual(self.form.getWidgetState('comboBox_field')['value'], initial_combobox_value)
+
+        self.assertEqual(self.form.getWidgetState('comboBox_field')[
+                         'value'], initial_combobox_value)
 
         final_combobox_value = 1
         self.form.getWidget('comboBox').setCurrentIndex(final_combobox_value)
-        
-        self.assertEqual(self.form.getWidgetState('comboBox_field')['value'], final_combobox_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'comboBox_field')['value'], final_combobox_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QDoubleSpinBox_value(self):
         # Check that the value of the QDoubleSpinBox is saved to the state
-        
+
         initial_doubleSpinBox_value = 0.0
-        
-        self.assertEqual(self.form.getWidgetState('doubleSpinBox_field')['value'], initial_doubleSpinBox_value)
+
+        self.assertEqual(self.form.getWidgetState('doubleSpinBox_field')[
+                         'value'], initial_doubleSpinBox_value)
 
         final_doubleSpinBox_value = 1.0
-        self.form.getWidget('doubleSpinBox').setValue(final_doubleSpinBox_value)
-        
-        self.assertEqual(self.form.getWidgetState('doubleSpinBox_field')['value'], final_doubleSpinBox_value)
+        self.form.getWidget('doubleSpinBox').setValue(
+            final_doubleSpinBox_value)
+
+        self.assertEqual(self.form.getWidgetState('doubleSpinBox_field')[
+                         'value'], final_doubleSpinBox_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QSpinBox_value(self):
         # Check that the value of the QSpinBox is saved to the state
-        
+
         initial_spinBox_value = 0
-        
-        self.assertEqual(self.form.getWidgetState('spinBox_field')['value'], initial_spinBox_value)
+
+        self.assertEqual(self.form.getWidgetState('spinBox_field')[
+                         'value'], initial_spinBox_value)
 
         final_spinBox_value = 1
         self.form.getWidget('spinBox').setValue(final_spinBox_value)
-        
-        self.assertEqual(self.form.getWidgetState('spinBox_field')['value'], final_spinBox_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'spinBox_field')['value'], final_spinBox_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QSlider_value(self):
         # Check that the value of the QSlider is saved to the state
-        
+
         initial_slider_value = 0
-        
-        self.assertEqual(self.form.getWidgetState('slider_field')['value'], initial_slider_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'slider_field')['value'], initial_slider_value)
 
         final_slider_value = 1
         self.form.getWidget('slider').setValue(final_slider_value)
-        
-        self.assertEqual(self.form.getWidgetState('slider_field')['value'], final_slider_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'slider_field')['value'], final_slider_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_UISliderWidget_value(self):
         # Check that the value of the UISliderWidget is returned in the state
-        
+
         initial_slider_value = 0
-        
-        self.assertEqual(self.form.getWidgetState('uiSliderWidget_field')['value'], initial_slider_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'uiSliderWidget_field')['value'], initial_slider_value)
 
         final_slider_value = 1
         self.form.getWidget('uiSliderWidget').setValue(final_slider_value)
-        
-        self.assertEqual(self.form.getWidgetState('uiSliderWidget_field')['value'], final_slider_value)
 
-    @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")    
+        self.assertEqual(self.form.getWidgetState(
+            'uiSliderWidget_field')['value'], final_slider_value)
+
+    @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QLineEdit_value(self):
         # Check that the value of the QLineEdit is saved to the state
-        
+
         initial_lineEdit_value = ''
         self.form.getWidget('lineEdit').setText(initial_lineEdit_value)
-        
-        self.assertEqual(self.form.getWidgetState('lineEdit_field')['value'], initial_lineEdit_value)
+
+        self.assertEqual(self.form.getWidgetState('lineEdit_field')[
+                         'value'], initial_lineEdit_value)
 
         final_lineEdit_value = 'test'
         self.form.getWidget('lineEdit').setText(final_lineEdit_value)
-        
-        self.assertEqual(self.form.getWidgetState('lineEdit_field')['value'], final_lineEdit_value)
 
-    @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")    
+        self.assertEqual(self.form.getWidgetState(
+            'lineEdit_field')['value'], final_lineEdit_value)
+
+    @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QTextEdit_value(self):
         # Check that the value of the QTextEdit is saved to the state
-        
+
         initial_textEdit_value = ''
         self.form.getWidget('textEdit').setText(initial_textEdit_value)
-        
-        self.assertEqual(self.form.getWidgetState('textEdit_field')['value'], initial_textEdit_value)
+
+        self.assertEqual(self.form.getWidgetState('textEdit_field')[
+                         'value'], initial_textEdit_value)
 
         final_textEdit_value = 'test'
         self.form.getWidget('textEdit').setText(final_textEdit_value)
-        
-        self.assertEqual(self.form.getWidgetState('textEdit_field')['value'], final_textEdit_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'textEdit_field')['value'], final_textEdit_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QPlainTextEdit_value(self):
         # Check that the value of the QPlainTextEdit is saved to the state
-        
+
         initial_plainTextEdit_value = ''
-        self.form.getWidget('plainTextEdit').setPlainText(initial_plainTextEdit_value)
-        
-        self.assertEqual(self.form.getWidgetState('plainTextEdit_field')['value'], initial_plainTextEdit_value)
+        self.form.getWidget('plainTextEdit').setPlainText(
+            initial_plainTextEdit_value)
+
+        self.assertEqual(self.form.getWidgetState('plainTextEdit_field')[
+                         'value'], initial_plainTextEdit_value)
 
         final_plainTextEdit_value = 'test'
-        self.form.getWidget('plainTextEdit').setPlainText(final_plainTextEdit_value)
-        
-        self.assertEqual(self.form.getWidgetState('plainTextEdit_field')['value'], final_plainTextEdit_value)
+        self.form.getWidget('plainTextEdit').setPlainText(
+            final_plainTextEdit_value)
+
+        self.assertEqual(self.form.getWidgetState('plainTextEdit_field')[
+                         'value'], final_plainTextEdit_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QPushButton_value(self):
         # Check that the value of the QPushButton is saved to the state
-        
+
         initial_button_value = False
-        
-        self.assertEqual(self.form.getWidgetState('button_field')['value'], initial_button_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'button_field')['value'], initial_button_value)
 
         final_button_value = True
         self.form.getWidget('button').setCheckable(True)
         self.form.getWidget('button').setChecked(final_button_value)
-        
-        self.assertEqual(self.form.getWidgetState('button_field')['value'], final_button_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'button_field')['value'], final_button_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QRadioButton_value(self):
         # Check that the value of the QRadioButton is saved to the state
-        
+
         initial_radio_value = False
-        
-        self.assertEqual(self.form.getWidgetState('radioButton_field')['value'], initial_radio_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'radioButton_field')['value'], initial_radio_value)
 
         final_radio_value = True
         self.form.getWidget('radioButton').setChecked(final_radio_value)
-        
-        self.assertEqual(self.form.getWidgetState('radioButton_field')['value'], final_radio_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'radioButton_field')['value'], final_radio_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
-    def test_applyWidgetStates(self):   
+    def test_applyWidgetStates(self):
         state_to_set = {
             'checkBox_field': {'value': True, 'enabled': False, 'visible': False},
             'label_field': {'value': 'applyWidgetStates Test', 'enabled': True, 'visible': False}
@@ -657,33 +756,41 @@ class FormWidgetStateTest(unittest.TestCase):
 
         self.simple_form.applyWidgetStates(state_to_set)
 
-        self.assertEqual(self.simple_form.getWidgetState('checkBox_field'), state_to_set['checkBox_field'])
-        self.assertEqual(self.simple_form.getWidgetState('label_field'), state_to_set['label_field'])
+        self.assertEqual(self.simple_form.getWidgetState(
+            'checkBox_field'), state_to_set['checkBox_field'])
+        self.assertEqual(self.simple_form.getWidgetState(
+            'label_field'), state_to_set['label_field'])
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_applyWidgetState(self):
         state_to_set = {'value': True, 'enabled': False, 'visible': False}
         self.simple_form.applyWidgetState('checkBox_field', state_to_set)
-        self.assertEqual(self.simple_form.getWidgetState('checkBox_field'), state_to_set)
+        self.assertEqual(self.simple_form.getWidgetState(
+            'checkBox_field'), state_to_set)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_applyWidgetState_using_role_parameter_field(self):
         state_to_set = {'value': True, 'enabled': False, 'visible': False}
-        self.simple_form.applyWidgetState('checkBox', state_to_set, role='field')
-        self.assertEqual(self.simple_form.getWidgetState('checkBox','field'), state_to_set)
+        self.simple_form.applyWidgetState(
+            'checkBox', state_to_set, role='field')
+        self.assertEqual(self.simple_form.getWidgetState(
+            'checkBox', 'field'), state_to_set)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_applyWidgetState_using_role_parameter_label(self):
-        state_to_set = {'value': 'test the checkbox:', 'enabled': False, 'visible': False}
-        self.simple_form.applyWidgetState('checkBox', state_to_set, role='label')
-        self.assertEqual(self.simple_form.getWidgetState('checkBox','label'), state_to_set)
+        state_to_set = {'value': 'test the checkbox:',
+                        'enabled': False, 'visible': False}
+        self.simple_form.applyWidgetState(
+            'checkBox', state_to_set, role='label')
+        self.assertEqual(self.simple_form.getWidgetState(
+            'checkBox', 'label'), state_to_set)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_applyWidgetState_using_role_parameter_default(self):
         state_to_set = {'value': True, 'enabled': False, 'visible': False}
         self.simple_form.applyWidgetState('checkBox', state_to_set)
-        self.assertEqual(self.simple_form.getWidgetState('checkBox'), state_to_set)
-
+        self.assertEqual(self.simple_form.getWidgetState(
+            'checkBox'), state_to_set)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getAllWidgetStates(self):
@@ -697,7 +804,6 @@ class FormWidgetStateTest(unittest.TestCase):
         }
 
         self.assertEqual(self.simple_form.getAllWidgetStates(), expected_state)
-
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_saveAllWidgetStates(self):
@@ -718,7 +824,7 @@ class FormWidgetStateTest(unittest.TestCase):
     def test_restoreAllSavedWidgetStates(self):
         # Check that the state of all widgets is restored from the state variable
 
-        state_to_restore= {
+        state_to_restore = {
             'checkBox_field': {'value': True, 'enabled': False, 'visible': False},
             'label_field': {'value': 'applyWidgetStates Test', 'enabled': True, 'visible': False},
             'checkBox_label': {'value': 'CheckBox Test: ', 'enabled': True, 'visible': False},
@@ -729,18 +835,30 @@ class FormWidgetStateTest(unittest.TestCase):
 
         self.simple_form.restoreAllSavedWidgetStates()
 
-        self.assertEqual(self.simple_form.getWidget('checkBox').isChecked(), state_to_restore['checkBox_field']['value'])
-        self.assertEqual(self.simple_form.getWidget('checkBox').isEnabled(), state_to_restore['checkBox_field']['enabled'])
-        self.assertEqual(self.simple_form.getWidget('checkBox').isVisible(), state_to_restore['checkBox_field']['visible'])
-        self.assertEqual(self.simple_form.getWidget('checkBox', 'label').text(), state_to_restore['checkBox_label']['value'])
-        self.assertEqual(self.simple_form.getWidget('checkBox', 'label').isEnabled(), state_to_restore['checkBox_label']['enabled'])
-        self.assertEqual(self.simple_form.getWidget('checkBox', 'label').isVisible(), state_to_restore['checkBox_label']['visible'])
-        self.assertEqual(self.simple_form.getWidget('label').text(), state_to_restore['label_field']['value'])
-        self.assertEqual(self.simple_form.getWidget('label').isEnabled(), state_to_restore['label_field']['enabled'])
-        self.assertEqual(self.simple_form.getWidget('label').isVisible(), state_to_restore['label_field']['visible'])
-        self.assertEqual(self.simple_form.getWidget('label', 'label').text(), state_to_restore['label_label']['value'])
-        self.assertEqual(self.simple_form.getWidget('label', 'label').isEnabled(), state_to_restore['label_label']['enabled'])
-        self.assertEqual(self.simple_form.getWidget('label', 'label').isVisible(), state_to_restore['label_label']['visible'])
+        self.assertEqual(self.simple_form.getWidget(
+            'checkBox').isChecked(), state_to_restore['checkBox_field']['value'])
+        self.assertEqual(self.simple_form.getWidget(
+            'checkBox').isEnabled(), state_to_restore['checkBox_field']['enabled'])
+        self.assertEqual(self.simple_form.getWidget(
+            'checkBox').isVisible(), state_to_restore['checkBox_field']['visible'])
+        self.assertEqual(self.simple_form.getWidget(
+            'checkBox', 'label').text(), state_to_restore['checkBox_label']['value'])
+        self.assertEqual(self.simple_form.getWidget(
+            'checkBox', 'label').isEnabled(), state_to_restore['checkBox_label']['enabled'])
+        self.assertEqual(self.simple_form.getWidget(
+            'checkBox', 'label').isVisible(), state_to_restore['checkBox_label']['visible'])
+        self.assertEqual(self.simple_form.getWidget(
+            'label').text(), state_to_restore['label_field']['value'])
+        self.assertEqual(self.simple_form.getWidget(
+            'label').isEnabled(), state_to_restore['label_field']['enabled'])
+        self.assertEqual(self.simple_form.getWidget(
+            'label').isVisible(), state_to_restore['label_field']['visible'])
+        self.assertEqual(self.simple_form.getWidget(
+            'label', 'label').text(), state_to_restore['label_label']['value'])
+        self.assertEqual(self.simple_form.getWidget(
+            'label', 'label').isEnabled(), state_to_restore['label_label']['enabled'])
+        self.assertEqual(self.simple_form.getWidget(
+            'label', 'label').isVisible(), state_to_restore['label_label']['visible'])
 
 
 @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
@@ -752,7 +870,7 @@ class FormDockWidgetStateTest(unittest.TestCase):
         add_every_widget_to_form(self.form)
         self.simple_form = FormDockWidget()
         add_two_widgets_to_form(self.simple_form)
-        
+
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_visibility(self):
         # Check that the visibility of the widget is saved to the state
@@ -760,94 +878,109 @@ class FormDockWidgetStateTest(unittest.TestCase):
         # to be True, because the FormDialog is not visible
         initial_label_visibility = True
         self.form.getWidget('label').isVisible = mock.MagicMock()
-        self.form.getWidget('label').isVisible.return_value = initial_label_visibility
-        
-        self.assertEqual(self.form.getWidgetState('label_field')['visible'], initial_label_visibility)
+        self.form.getWidget(
+            'label').isVisible.return_value = initial_label_visibility
+
+        self.assertEqual(self.form.getWidgetState('label_field')[
+                         'visible'], initial_label_visibility)
 
         final_label_visibility = False
         self.form.getWidget('label').isVisible.return_value = False
 
-        self.assertEqual(self.form.getWidgetState('label_field')['visible'], final_label_visibility)
+        self.assertEqual(self.form.getWidgetState('label_field')[
+                         'visible'], final_label_visibility)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_enabled_state(self):
         # Check that the enabled state of the widget is saved to the state
-        
+
         initial_label_enabled_state = True
-        
-        self.assertEqual(self.form.getWidgetState('label_field')['enabled'], initial_label_enabled_state)
+
+        self.assertEqual(self.form.getWidgetState('label_field')[
+                         'enabled'], initial_label_enabled_state)
 
         self.form.getWidget('label').setEnabled(False)
         final_label_enabled_state = False
 
-        self.assertEqual(self.form.getWidgetState('label_field')['enabled'], final_label_enabled_state)
+        self.assertEqual(self.form.getWidgetState('label_field')[
+                         'enabled'], final_label_enabled_state)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_value_using_role_parameter_field(self):
         # Check that the value of the QLabel is saved to the state
-        
-        initial_label_value ='test label'
-        
-        self.assertEqual(self.form.getWidgetState('label', 'field')['value'], initial_label_value)
+
+        initial_label_value = 'test label'
+
+        self.assertEqual(self.form.getWidgetState(
+            'label', 'field')['value'], initial_label_value)
 
         final_label_value = 'final test label'
         self.form.getWidget('label').setText(final_label_value)
-        
-        self.assertEqual(self.form.getWidgetState('label','field')['value'], final_label_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'label', 'field')['value'], final_label_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_value_using_role_parameter_label(self):
         # Check that the value of the QLabel is saved to the state
-        
-        initial_label_value ='test label'
-        
-        self.assertEqual(self.form.getWidgetState('label', 'field')['value'], initial_label_value)
+
+        initial_label_value = 'test label'
+
+        self.assertEqual(self.form.getWidgetState(
+            'label', 'field')['value'], initial_label_value)
 
         final_label_value = 'final test label'
         self.form.getWidget('label').setText(final_label_value)
-        
-        self.assertEqual(self.form.getWidgetState('label','field')['value'], final_label_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'label', 'field')['value'], final_label_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_value_using_default_role_parameter(self):
         # Check that the value of the QLabel is saved to the state
-        initial_label_value ='test label'
-        
+        initial_label_value = 'test label'
+
         # In getWidgetState we do not specify if we want the 'field' or 'label' role, so it should default to 'field':
-        self.assertEqual(self.form.getWidgetState('label')['value'], initial_label_value)
+        self.assertEqual(self.form.getWidgetState(
+            'label')['value'], initial_label_value)
 
         final_label_value = 'final test label'
         self.form.getWidget('label').setText(final_label_value)
-        
-        self.assertEqual(self.form.getWidgetState('label')['value'], final_label_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'label')['value'], final_label_value)
 
     # Test value is saved for all widget types ----------------------------------------------------------------
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QLabel_value(self):
         # Check that the value of the QLabel is saved to the state
-        
-        initial_label_value ='test label'
-        
-        self.assertEqual(self.form.getWidgetState('label_field')['value'], initial_label_value)
+
+        initial_label_value = 'test label'
+
+        self.assertEqual(self.form.getWidgetState(
+            'label_field')['value'], initial_label_value)
 
         final_label_value = 'final test label'
         self.form.getWidget('label').setText(final_label_value)
-        
-        self.assertEqual(self.form.getWidgetState('label_field')['value'], final_label_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'label_field')['value'], final_label_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QCheckBox_value(self):
         # Check that the value of the QCheckBox is saved to the state
-        
+
         initial_checkbox_value = False
-        
-        self.assertEqual(self.form.getWidgetState('checkBox_field')['value'], initial_checkbox_value)
+
+        self.assertEqual(self.form.getWidgetState('checkBox_field')[
+                         'value'], initial_checkbox_value)
 
         final_checkbox_value = True
         self.form.getWidget('checkBox').setChecked(final_checkbox_value)
-        
-        self.assertEqual(self.form.getWidgetState('checkBox_field')['value'], final_checkbox_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'checkBox_field')['value'], final_checkbox_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QComboBox_value(self):
@@ -855,139 +988,162 @@ class FormDockWidgetStateTest(unittest.TestCase):
 
         combobox_list = ['test', 'test2']
         self.form.getWidget('comboBox').addItems(combobox_list)
-        
+
         initial_combobox_value = 0
-        
-        self.assertEqual(self.form.getWidgetState('comboBox_field')['value'], initial_combobox_value)
+
+        self.assertEqual(self.form.getWidgetState('comboBox_field')[
+                         'value'], initial_combobox_value)
 
         final_combobox_value = 1
         self.form.getWidget('comboBox').setCurrentIndex(final_combobox_value)
-        
-        self.assertEqual(self.form.getWidgetState('comboBox_field')['value'], final_combobox_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'comboBox_field')['value'], final_combobox_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QDoubleSpinBox_value(self):
         # Check that the value of the QDoubleSpinBox is saved to the state
-        
+
         initial_doubleSpinBox_value = 0.0
-        
-        self.assertEqual(self.form.getWidgetState('doubleSpinBox_field')['value'], initial_doubleSpinBox_value)
+
+        self.assertEqual(self.form.getWidgetState('doubleSpinBox_field')[
+                         'value'], initial_doubleSpinBox_value)
 
         final_doubleSpinBox_value = 1.0
-        self.form.getWidget('doubleSpinBox').setValue(final_doubleSpinBox_value)
-        
-        self.assertEqual(self.form.getWidgetState('doubleSpinBox_field')['value'], final_doubleSpinBox_value)
+        self.form.getWidget('doubleSpinBox').setValue(
+            final_doubleSpinBox_value)
+
+        self.assertEqual(self.form.getWidgetState('doubleSpinBox_field')[
+                         'value'], final_doubleSpinBox_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QSpinBox_value(self):
         # Check that the value of the QSpinBox is saved to the state
-        
+
         initial_spinBox_value = 0
-        
-        self.assertEqual(self.form.getWidgetState('spinBox_field')['value'], initial_spinBox_value)
+
+        self.assertEqual(self.form.getWidgetState('spinBox_field')[
+                         'value'], initial_spinBox_value)
 
         final_spinBox_value = 1
         self.form.getWidget('spinBox').setValue(final_spinBox_value)
-        
-        self.assertEqual(self.form.getWidgetState('spinBox_field')['value'], final_spinBox_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'spinBox_field')['value'], final_spinBox_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QSlider_value(self):
         # Check that the value of the QSlider is saved to the state
-        
+
         initial_slider_value = 0
-        
-        self.assertEqual(self.form.getWidgetState('slider_field')['value'], initial_slider_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'slider_field')['value'], initial_slider_value)
 
         final_slider_value = 1
         self.form.getWidget('slider').setValue(final_slider_value)
-        
-        self.assertEqual(self.form.getWidgetState('slider_field')['value'], final_slider_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'slider_field')['value'], final_slider_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_UISliderWidget_value(self):
         # Check that the value of the UISliderWidget is returned in the state
-        
+
         initial_slider_value = 0
-        
-        self.assertEqual(self.form.getWidgetState('uiSliderWidget_field')['value'], initial_slider_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'uiSliderWidget_field')['value'], initial_slider_value)
 
         final_slider_value = 1
         self.form.getWidget('uiSliderWidget').setValue(final_slider_value)
-        
-        self.assertEqual(self.form.getWidgetState('uiSliderWidget_field')['value'], final_slider_value)
 
-    @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")    
+        self.assertEqual(self.form.getWidgetState(
+            'uiSliderWidget_field')['value'], final_slider_value)
+
+    @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QLineEdit_value(self):
         # Check that the value of the QLineEdit is saved to the state
-        
+
         initial_lineEdit_value = ''
         self.form.getWidget('lineEdit').setText(initial_lineEdit_value)
-        
-        self.assertEqual(self.form.getWidgetState('lineEdit_field')['value'], initial_lineEdit_value)
+
+        self.assertEqual(self.form.getWidgetState('lineEdit_field')[
+                         'value'], initial_lineEdit_value)
 
         final_lineEdit_value = 'test'
         self.form.getWidget('lineEdit').setText(final_lineEdit_value)
-        
-        self.assertEqual(self.form.getWidgetState('lineEdit_field')['value'], final_lineEdit_value)
 
-    @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")    
+        self.assertEqual(self.form.getWidgetState(
+            'lineEdit_field')['value'], final_lineEdit_value)
+
+    @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QTextEdit_value(self):
         # Check that the value of the QTextEdit is saved to the state
-        
+
         initial_textEdit_value = ''
         self.form.getWidget('textEdit').setText(initial_textEdit_value)
-        
-        self.assertEqual(self.form.getWidgetState('textEdit_field')['value'], initial_textEdit_value)
+
+        self.assertEqual(self.form.getWidgetState('textEdit_field')[
+                         'value'], initial_textEdit_value)
 
         final_textEdit_value = 'test'
         self.form.getWidget('textEdit').setText(final_textEdit_value)
-        
-        self.assertEqual(self.form.getWidgetState('textEdit_field')['value'], final_textEdit_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'textEdit_field')['value'], final_textEdit_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QPlainTextEdit_value(self):
         # Check that the value of the QPlainTextEdit is saved to the state
-        
+
         initial_plainTextEdit_value = ''
-        self.form.getWidget('plainTextEdit').setPlainText(initial_plainTextEdit_value)
-        
-        self.assertEqual(self.form.getWidgetState('plainTextEdit_field')['value'], initial_plainTextEdit_value)
+        self.form.getWidget('plainTextEdit').setPlainText(
+            initial_plainTextEdit_value)
+
+        self.assertEqual(self.form.getWidgetState('plainTextEdit_field')[
+                         'value'], initial_plainTextEdit_value)
 
         final_plainTextEdit_value = 'test'
-        self.form.getWidget('plainTextEdit').setPlainText(final_plainTextEdit_value)
-        
-        self.assertEqual(self.form.getWidgetState('plainTextEdit_field')['value'], final_plainTextEdit_value)
+        self.form.getWidget('plainTextEdit').setPlainText(
+            final_plainTextEdit_value)
+
+        self.assertEqual(self.form.getWidgetState('plainTextEdit_field')[
+                         'value'], final_plainTextEdit_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QPushButton_value(self):
         # Check that the value of the QPushButton is saved to the state
-        
+
         initial_button_value = False
-        
-        self.assertEqual(self.form.getWidgetState('button_field')['value'], initial_button_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'button_field')['value'], initial_button_value)
 
         final_button_value = True
         self.form.getWidget('button').setCheckable(True)
         self.form.getWidget('button').setChecked(final_button_value)
-        
-        self.assertEqual(self.form.getWidgetState('button_field')['value'], final_button_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'button_field')['value'], final_button_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getWidgetState_returns_QRadioButton_value(self):
         # Check that the value of the QRadioButton is saved to the state
-        
+
         initial_radio_value = False
-        
-        self.assertEqual(self.form.getWidgetState('radioButton_field')['value'], initial_radio_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'radioButton_field')['value'], initial_radio_value)
 
         final_radio_value = True
         self.form.getWidget('radioButton').setChecked(final_radio_value)
-        
-        self.assertEqual(self.form.getWidgetState('radioButton_field')['value'], final_radio_value)
+
+        self.assertEqual(self.form.getWidgetState(
+            'radioButton_field')['value'], final_radio_value)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
-    def test_applyWidgetStates(self):   
+    def test_applyWidgetStates(self):
         state_to_set = {
             'checkBox_field': {'value': True, 'enabled': False, 'visible': False},
             'label_field': {'value': 'applyWidgetStates Test', 'enabled': True, 'visible': False}
@@ -995,33 +1151,41 @@ class FormDockWidgetStateTest(unittest.TestCase):
 
         self.simple_form.applyWidgetStates(state_to_set)
 
-        self.assertEqual(self.simple_form.getWidgetState('checkBox_field'), state_to_set['checkBox_field'])
-        self.assertEqual(self.simple_form.getWidgetState('label_field'), state_to_set['label_field'])
+        self.assertEqual(self.simple_form.getWidgetState(
+            'checkBox_field'), state_to_set['checkBox_field'])
+        self.assertEqual(self.simple_form.getWidgetState(
+            'label_field'), state_to_set['label_field'])
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_applyWidgetState(self):
         state_to_set = {'value': True, 'enabled': False, 'visible': False}
         self.simple_form.applyWidgetState('checkBox_field', state_to_set)
-        self.assertEqual(self.simple_form.getWidgetState('checkBox_field'), state_to_set)
+        self.assertEqual(self.simple_form.getWidgetState(
+            'checkBox_field'), state_to_set)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_applyWidgetState_using_role_parameter_field(self):
         state_to_set = {'value': True, 'enabled': False, 'visible': False}
-        self.simple_form.applyWidgetState('checkBox', state_to_set, role='field')
-        self.assertEqual(self.simple_form.getWidgetState('checkBox','field'), state_to_set)
+        self.simple_form.applyWidgetState(
+            'checkBox', state_to_set, role='field')
+        self.assertEqual(self.simple_form.getWidgetState(
+            'checkBox', 'field'), state_to_set)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_applyWidgetState_using_role_parameter_label(self):
-        state_to_set = {'value': 'test the checkbox:', 'enabled': False, 'visible': False}
-        self.simple_form.applyWidgetState('checkBox', state_to_set, role='label')
-        self.assertEqual(self.simple_form.getWidgetState('checkBox','label'), state_to_set)
+        state_to_set = {'value': 'test the checkbox:',
+                        'enabled': False, 'visible': False}
+        self.simple_form.applyWidgetState(
+            'checkBox', state_to_set, role='label')
+        self.assertEqual(self.simple_form.getWidgetState(
+            'checkBox', 'label'), state_to_set)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_applyWidgetState_using_role_parameter_default(self):
         state_to_set = {'value': True, 'enabled': False, 'visible': False}
         self.simple_form.applyWidgetState('checkBox', state_to_set)
-        self.assertEqual(self.simple_form.getWidgetState('checkBox'), state_to_set)
-
+        self.assertEqual(self.simple_form.getWidgetState(
+            'checkBox'), state_to_set)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_getAllWidgetStates(self):
@@ -1036,7 +1200,6 @@ class FormDockWidgetStateTest(unittest.TestCase):
 
         self.assertEqual(self.simple_form.getAllWidgetStates(), expected_state)
 
-
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_saveAllWidgetStates(self):
         # Check that the state of all widgets is saved to the state variable
@@ -1050,13 +1213,14 @@ class FormDockWidgetStateTest(unittest.TestCase):
 
         self.simple_form.saveAllWidgetStates()
 
-        self.assertEqual(self.simple_form.widget().widget_states, expected_state)
+        self.assertEqual(
+            self.simple_form.widget().widget_states, expected_state)
 
     @unittest.skipIf(skip_test, "Can't test interfaces if we can't connect to the display")
     def test_restoreAllSavedWidgetStates(self):
         # Check that the state of all widgets is restored from the state variable
 
-        state_to_restore= {
+        state_to_restore = {
             'checkBox_field': {'value': True, 'enabled': False, 'visible': False},
             'label_field': {'value': 'applyWidgetStates Test', 'enabled': True, 'visible': False},
             'checkBox_label': {'value': 'CheckBox Test: ', 'enabled': True, 'visible': False},
@@ -1067,20 +1231,31 @@ class FormDockWidgetStateTest(unittest.TestCase):
 
         self.simple_form.restoreAllSavedWidgetStates()
 
-        self.assertEqual(self.simple_form.getWidget('checkBox').isChecked(), state_to_restore['checkBox_field']['value'])
-        self.assertEqual(self.simple_form.getWidget('checkBox').isEnabled(), state_to_restore['checkBox_field']['enabled'])
-        self.assertEqual(self.simple_form.getWidget('checkBox').isVisible(), state_to_restore['checkBox_field']['visible'])
-        self.assertEqual(self.simple_form.getWidget('checkBox', 'label').text(), state_to_restore['checkBox_label']['value'])
-        self.assertEqual(self.simple_form.getWidget('checkBox', 'label').isEnabled(), state_to_restore['checkBox_label']['enabled'])
-        self.assertEqual(self.simple_form.getWidget('checkBox', 'label').isVisible(), state_to_restore['checkBox_label']['visible'])
-        self.assertEqual(self.simple_form.getWidget('label').text(), state_to_restore['label_field']['value'])
-        self.assertEqual(self.simple_form.getWidget('label').isEnabled(), state_to_restore['label_field']['enabled'])
-        self.assertEqual(self.simple_form.getWidget('label').isVisible(), state_to_restore['label_field']['visible'])
-        self.assertEqual(self.simple_form.getWidget('label', 'label').text(), state_to_restore['label_label']['value'])
-        self.assertEqual(self.simple_form.getWidget('label', 'label').isEnabled(), state_to_restore['label_label']['enabled'])
-        self.assertEqual(self.simple_form.getWidget('label', 'label').isVisible(), state_to_restore['label_label']['visible'])
+        self.assertEqual(self.simple_form.getWidget(
+            'checkBox').isChecked(), state_to_restore['checkBox_field']['value'])
+        self.assertEqual(self.simple_form.getWidget(
+            'checkBox').isEnabled(), state_to_restore['checkBox_field']['enabled'])
+        self.assertEqual(self.simple_form.getWidget(
+            'checkBox').isVisible(), state_to_restore['checkBox_field']['visible'])
+        self.assertEqual(self.simple_form.getWidget(
+            'checkBox', 'label').text(), state_to_restore['checkBox_label']['value'])
+        self.assertEqual(self.simple_form.getWidget(
+            'checkBox', 'label').isEnabled(), state_to_restore['checkBox_label']['enabled'])
+        self.assertEqual(self.simple_form.getWidget(
+            'checkBox', 'label').isVisible(), state_to_restore['checkBox_label']['visible'])
+        self.assertEqual(self.simple_form.getWidget(
+            'label').text(), state_to_restore['label_field']['value'])
+        self.assertEqual(self.simple_form.getWidget(
+            'label').isEnabled(), state_to_restore['label_field']['enabled'])
+        self.assertEqual(self.simple_form.getWidget(
+            'label').isVisible(), state_to_restore['label_field']['visible'])
+        self.assertEqual(self.simple_form.getWidget(
+            'label', 'label').text(), state_to_restore['label_label']['value'])
+        self.assertEqual(self.simple_form.getWidget(
+            'label', 'label').isEnabled(), state_to_restore['label_label']['enabled'])
+        self.assertEqual(self.simple_form.getWidget(
+            'label', 'label').isVisible(), state_to_restore['label_label']['visible'])
 
 
 if __name__ == '__main__':
     unittest.main()
-        

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -22,13 +22,21 @@ class TestZipDirectory(unittest.TestCase):
         with open(self.subfile, "w+") as f:
             f.write("test")
 
-    def test_zip_directory(self):
-        zip_directory(self.folder)
+    def _test_zip_directory(self):
         # Check the zip file exists:
         assert os.path.exists(self.folder + ".zip")
         # extract the zipfile and check the subfile exists:
         shutil.unpack_archive(self.folder + ".zip", "extracted")
         assert os.path.exists(os.path.join("extracted", "Test Subfolder", "test_file.txt"))
+
+    def test_zip_directory_compress_True(self):
+        zip_directory(self.folder)
+        self._test_zip_directory()
+
+    def test_zip_directory_compress_False(self):
+        zip_directory(self.folder, compress=False)
+        self._test_zip_directory()
+
 
     def tearDown(self):
         shutil.rmtree(self.folder)

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -1,0 +1,38 @@
+from eqt.io import zip_directory
+import unittest
+import os
+import shutil
+
+class TestZipDirectory(unittest.TestCase):
+
+    def setUp(self):
+        '''
+        Create a session zip file, which contains a session.json file
+        '''
+        self.title="title"
+        self.app_name="app_name"
+
+        self.folder = "Test Folder"
+        self.subfolder = os.path.join(self.folder, "Test Subfolder")
+        self.subfile = os.path.join(self.subfolder, "test_file.txt")
+
+        os.mkdir(self.folder)
+        os.mkdir(self.subfolder)
+
+        with open(self.subfile, "w+") as f:
+            f.write("test")
+
+    def test_zip_directory(self):
+        zip_directory(self.folder)
+        # Check the zip file exists:
+        assert os.path.exists(self.folder + ".zip")
+        # extract the zipfile and check the subfile exists:
+        shutil.unpack_archive(self.folder + ".zip", "extracted")
+        assert os.path.exists(os.path.join("extracted", "Test Subfolder", "test_file.txt"))
+
+    def tearDown(self):
+        shutil.rmtree(self.folder)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -3,14 +3,15 @@ import unittest
 import os
 import shutil
 
+
 class TestZipDirectory(unittest.TestCase):
 
     def setUp(self):
         '''
         Create a session zip file, which contains a session.json file
         '''
-        self.title="title"
-        self.app_name="app_name"
+        self.title = "title"
+        self.app_name = "app_name"
 
         self.folder = "Test Folder"
         self.subfolder = os.path.join(self.folder, "Test Subfolder")
@@ -27,7 +28,8 @@ class TestZipDirectory(unittest.TestCase):
         assert os.path.exists(self.folder + ".zip")
         # extract the zipfile and check the subfile exists:
         shutil.unpack_archive(self.folder + ".zip", "extracted")
-        assert os.path.exists(os.path.join("extracted", "Test Subfolder", "test_file.txt"))
+        assert os.path.exists(os.path.join(
+            "extracted", "Test Subfolder", "test_file.txt"))
 
     def test_zip_directory_compress_True(self):
         zip_directory(self.folder)
@@ -36,7 +38,6 @@ class TestZipDirectory(unittest.TestCase):
     def test_zip_directory_compress_False(self):
         zip_directory(self.folder, compress=False)
         self._test_zip_directory()
-
 
     def tearDown(self):
         shutil.rmtree(self.folder)


### PR DESCRIPTION
This adds:
- `SessionsMainWindow.py` - which is a base class for our apps which create a session folder where any files generated in the app are saved, and provides the ability to permanently save and reload sessions.
- `SessionsMainWindow_example.py` - an example of using the SessionsMainWindow - you can run this example, change the state of widgets in the form, save the session, reload the session and see the state of the widgets be restored.
- `SessionsDialogs.py` - the dialogs used by the `SessionsMainWindow.py` 
- `io.py` - contains method for zipping a directory, used by `SessionsMainWindow.py`