### PR TITLE
Remove unittest_parametrize from eqt_env recipe dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Version x.x.x
+- Remove `unittest_parametrize` from `eqt_env` recipe dependencies (#180)
+
 # Version 2.0.0
 - Use `qtpy` as virtual Qt binding package. GHA unit tests are run with PySide2 and PyQt5 (#146)
 - Add `pyqt_env.yml`  and `pyside_env.yml` environment files (#146)

--- a/recipe/eqt_env.yml
+++ b/recipe/eqt_env.yml
@@ -6,4 +6,3 @@ dependencies:
   - pip
   - qtpy
   - qdarkstyle
-  - unittest_parametrize


### PR DESCRIPTION
#179 

This pull request removes the `unittest_parametrize` dependency from the `eqt_env.yml` recipe file. This package is only required when testing locally and as such has been included in the `pyproject.toml` list of optional dependencies. 