### PR TITLE
Added minimum requirements to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ Via `pip`/`conda`/`mamba`, i.e. any of the following:
 - `mamba install -c conda-forge eqt`
 
 
-#### Note:
-`eqt` uses the [`qtpy`](https://github.com/spyder-ide/qtpy) abstraction layer for Qt bindings, meaning that it works with either PySide or PyQt bindings. Thus, the package does not depend on either. If the environment does not already have a Qt binding then the user *must* install either `pyside2` or `pyqt5`.
+> [!IMPORTANT]
+> `eqt` uses the [`qtpy`](https://github.com/spyder-ide/qtpy) abstraction layer for Qt bindings, meaning that it works with either PySide or PyQt bindings. Thus, the package does not depend on either. If the environment does not already have a Qt binding then the user *must* install either `pyside2` or `pyqt5`.
+
+### Minimum requirements
+`eqt` depends on Python>=3.9
 
 ## Examples
 


### PR DESCRIPTION
Because of #184 and since the conda recipe is in the [feedstock](https://github.com/conda-forge/eqt-feedstock/) it is important to tell the user what the minimum requirements are.

- closes #184 with
- https://github.com/conda-forge/eqt-feedstock/pull/13